### PR TITLE
为管理端匹配触发增加 CSRF 防护

### DIFF
--- a/app.js
+++ b/app.js
@@ -68,6 +68,22 @@ function generateToken(size = 24) {
   return crypto.randomBytes(size).toString('hex');
 }
 
+function ensureCsrfToken(req) {
+  if (!req.session.csrfToken) {
+    req.session.csrfToken = generateToken(16);
+  }
+
+  return req.session.csrfToken;
+}
+
+function requireValidCsrf(req, res, next) {
+  if (req.body?.csrfToken && req.session.csrfToken === req.body.csrfToken) {
+    return next();
+  }
+
+  return res.redirect('/admin?msg=' + encodeURIComponent('请求无效，请刷新页面后重试') + '&type=error');
+}
+
 function regenerateSession(req) {
   return new Promise((resolve, reject) => {
     req.session.regenerate(error => {
@@ -356,12 +372,20 @@ app.get('/admin', isLoggedIn, async (req, res) => {
     user: req.user,
     users,
     weekNumber: getWeekNumber(),
+    csrfToken: ensureCsrfToken(req),
+    message: req.query.msg,
+    messageType: req.query.type,
     isAdmin: true
   });
 });
 
 // 手动触发匹配
 app.get('/admin/match', isLoggedIn, async (req, res) => {
+  if (!req.isAdmin) return res.redirect('/');
+  return res.redirect('/admin?msg=' + encodeURIComponent('请使用页面表单触发匹配') + '&type=error');
+});
+
+app.post('/admin/match', isLoggedIn, requireValidCsrf, async (req, res) => {
   if (!req.isAdmin) return res.redirect('/');
   const result = await runWeeklyMatch();
   res.redirect('/admin?msg=' + encodeURIComponent(result.message) + '&type=' + (result.success ? 'success' : 'error'));

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -2,7 +2,10 @@
   <h2>👥 用户管理</h2>
 
   <div style="margin-bottom: 20px;">
-    <a href="/admin/match" class="btn">🔄 手动触发本周匹配</a>
+    <form action="/admin/match" method="POST" style="display: inline;">
+      <input type="hidden" name="csrfToken" value="<%= csrfToken %>">
+      <button type="submit" class="btn">🔄 手动触发本周匹配</button>
+    </form>
     <span style="margin-left: 15px; color: #666;">当前第 <%= weekNumber %> 周</span>
   </div>
 


### PR DESCRIPTION
## 概要
- 将 `/admin/match` 从 `GET` 改为 `POST`
- 为管理页生成并校验 CSRF token，避免跨站请求直接触发周匹配
- 将管理页上的“手动触发本周匹配”入口改为表单提交

## 关联 issue
- Closes #7

## 验证
- `node --check app.js`