### PR TITLE
实现运行时版本信息接口

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,13 +44,22 @@ function wrapAsync(fn) {
   };
 }
 
+function normalizeShortCommitSha(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const match = value.trim().match(/[a-f0-9]{7,40}/i);
+  return match ? match[0].slice(0, 7).toLowerCase() : null;
+}
+
 let db;
 const app = express();
 const isProduction = process.env.NODE_ENV === 'production';
 const sessionSecret = process.env.SESSION_SECRET;
 const appVersion = process.env.APP_VERSION || packageJson.version;
 const fullCommitSha = process.env.GIT_COMMIT || null;
-const shortCommitSha = process.env.GIT_COMMIT_SHORT || (fullCommitSha ? fullCommitSha.slice(0, 7) : null);
+const shortCommitSha = normalizeShortCommitSha(process.env.GIT_COMMIT_SHORT) || normalizeShortCommitSha(fullCommitSha);
 const deployTime = process.env.DEPLOY_TIME || null;
 
 if (isProduction) {


### PR DESCRIPTION
## 概要

这条 PR 只处理 `#37` 当前最核心的缺口：文档已经约定可以通过 `/version` 查询线上版本，但主线里还没有真正的运行时实现。

## 修改内容

- 新增公开的 `GET /version` 路由
- `version` 默认读取 `package.json`，支持用 `APP_VERSION` 覆盖
- `commit` 优先读取 `GIT_COMMIT_SHORT`，否则从 `GIT_COMMIT` 截取 7 位短 SHA
- `deployedAt` 读取 `DEPLOY_TIME`
- 响应加 `Cache-Control: no-store`，避免版本信息被缓存

## 验证

- `node --check app.js`

## 关联

- Ref #37