### PR TITLE
对齐 PROJECT.md 的运行时表述

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -296,7 +296,7 @@ shu-date/
 **生产环境特性**：
 - 完全隐藏开发者工具
 - 强制要求 `SESSION_SECRET`
-- Session Cookie 当前配置为 `secure: false` / `proxy: false`（不会随 `NODE_ENV` 自动切换）
+- Session Cookie 的 `secure` / `proxy` 会根据 `NODE_ENV` 自动切换
 - 必须配置 `RESEND_API_KEY` 才能发送邮件
 
 ### 5.4 本地开发配置示例


### PR DESCRIPTION
## 概要

这条 PR 只处理 `#21` 当前在 `PROJECT.md` 中仍然明显漂移的文案：

- 将 `shudate.xyz` 从“后端服务”改成更准确的“应用地址”
- 将生产环境 Session 说明改成 `secure / proxy` 会根据 `NODE_ENV` 自动切换

## 说明

这条 PR 目前先以草稿形式提交，因为文档里的部分事实依赖前置修复 PR：

- #38 修复验证码登录的会话安全回归
- #40 实现运行时版本信息接口

等前置 PR 合并后，这条文档对齐就可以直接转为 ready。

## 关联

- Ref #21