### PR TITLE
让 /matches 优先读取本周正式匹配结果

### DIFF
--- a/app.js
+++ b/app.js
@@ -1001,7 +1001,8 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
       user: req.user,
       nickname: req.session.nickname,
       hasProfile: false,
-      showPassword: true
+      showPassword: true,
+      matchSource: 'weekly'
     });
   }
 
@@ -1010,8 +1011,33 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
     return res.redirect('/profile');
   }
 
-  const matchService = require('./matchService');
-  const matches = await matchService.getTopMatches(req.user.id, 10);
+  const weekNumber = getWeekNumber();
+  const weeklyMatch = await db.queryOne(`
+    SELECT
+      m.score,
+      partner.id AS user_id,
+      partner.email,
+      partner.nickname,
+      partner.name,
+      p.my_grade,
+      p.gender,
+      p.campus,
+      p.interests,
+      p.lovetype_code
+    FROM matches m
+    JOIN users partner
+      ON partner.id = CASE
+        WHEN m.user_id_1 = $1 THEN m.user_id_2
+        ELSE m.user_id_1
+      END
+    LEFT JOIN profiles p ON p.user_id = partner.id
+    WHERE m.week_number = $2
+      AND ($1 = m.user_id_1 OR $1 = m.user_id_2)
+    ORDER BY m.matched_at DESC, m.id DESC
+    LIMIT 1
+  `, [req.user.id, weekNumber]);
+
+  const matches = weeklyMatch ? [weeklyMatch] : [];
 
   res.render('matches', {
     title: '匹配结果',
@@ -1020,7 +1046,9 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
     hasProfile: true,
     showPassword: true,
     matches: matches,
-    isAdmin: req.isAdmin
+    isAdmin: req.isAdmin,
+    matchSource: 'weekly',
+    weekNumber
   });
 }));
 

--- a/views/matches.ejs
+++ b/views/matches.ejs
@@ -20,18 +20,18 @@
     <% } else if (!matches || matches.length === 0) { %>
     <div class="card" style="text-align: center;">
       <div style="font-size: 4rem; margin-bottom: 16px;">🤔</div>
-      <h2>暂无匹配</h2>
+      <h2>本周暂无正式匹配结果</h2>
       <p style="color: var(--muted-foreground); margin-bottom: 24px;">
-        内测阶段暂不支持匹配功能。
+        本周匹配尚未发布，或你本周暂未匹配成功。
       </p>
     </div>
     <% } else { %>
     <div class="card">
       <h2 style="display: flex; align-items: center; gap: 10px;">
-        💕 匹配结果
+        💕 本周正式匹配结果
       </h2>
       <p style="color: var(--muted-foreground); margin-bottom: 24px;">
-        根据你的问卷，为你推荐以下同学：
+        这是本周已经发布并落库的正式匹配结果：
       </p>
 
       <div style="display: grid; gap: 16px;">
@@ -51,19 +51,23 @@
               <strong>兴趣爱好:</strong> <%= m.interests || '-' %>
             </div>
           </div>
+          <% if (m.score !== null && m.score !== undefined) { %>
           <div class="match-score" style="
             background: <%= m.score >= 0.7 ? 'oklch(0.95 0.08 145)' : m.score >= 0.5 ? 'oklch(0.95 0.08 80)' : 'oklch(0.95 0.08 25)' %>;
             color: <%= m.score >= 0.7 ? 'oklch(0.4 0.12 145)' : m.score >= 0.5 ? 'oklch(0.45 0.12 80)' : 'oklch(0.45 0.15 25)' %>;
           ">
             <%= Math.round(m.score * 100) %>%
           </div>
+          <% } %>
         </div>
         <% }); %>
       </div>
 
+      <% if (matches.some(function(m) { return m.score !== null && m.score !== undefined; })) { %>
       <p style="margin-top: 24px; color: var(--muted-foreground); font-size: 0.85rem; text-align: center;">
         💡 匹配度算法：兴趣爱好30% + 生活习惯30% + 恋爱观念40%，再结合 LoveType 兼容性做加减分
       </p>
+      <% } %>
     </div>
     <% } %>
   </div>


### PR DESCRIPTION
﻿## 概要
- /matches 不再实时重算推荐结果，而是优先读取本周已经落库的 matches 结果
- 将页面文案明确为“本周正式匹配结果”
- 若本周尚未发布匹配，或当前用户本周未匹配成功，则展示对应空状态

## 验证
- `node --check app.js`

## 关联
- Ref #27
- 这是 #27 的第 2 条 PR，只切换 /matches 的读取链路与页面语义，不处理 API 收尾
