### PR TITLE
收拢正式匹配与实时推荐的边界

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -251,9 +251,9 @@ shu-date/
 | POST | /profile | 更新问卷 | 已登录 |
 | GET | /profile/password | 修改密码页 | 已登录 |
 | POST | /profile/password | 修改密码 | 已登录 |
-| GET | /matches | 匹配结果 | 已登录 |
-| GET | /api/matches | 获取匹配列表 | 已登录 |
-| GET | /api/match/top | 获取最佳匹配 | 已登录 |
+| GET | /matches | 查看本周正式匹配结果 | 已登录 |
+| GET | /api/matches | 获取实时推荐列表 | 已登录 |
+| GET | /api/match/top | 获取前 5 名实时推荐 | 已登录 |
 | GET | /admin | 管理后台 | 管理员 |
 | POST | /admin/match | 手动触发匹配 | 管理员 |
 | GET | /version | 版本信息 | 公开 |

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const crypto = require('crypto');
 const bcrypt = require('bcryptjs');
 const path = require('path');
 const packageJson = require('./package.json');
+const { getWeekNumber } = require('./weekNumber');
 require('dotenv').config();
 const lovetypeService = require('./lovetypeService');
 
@@ -1012,7 +1013,7 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
   }
 
   const weekNumber = getWeekNumber();
-  const weeklyMatch = await db.queryOne(`
+  const weeklyMatches = await db.query(`
     SELECT
       m.score,
       partner.id AS user_id,
@@ -1034,10 +1035,13 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
     WHERE m.week_number = $2
       AND ($1 = m.user_id_1 OR $1 = m.user_id_2)
     ORDER BY m.matched_at DESC, m.id DESC
-    LIMIT 1
   `, [req.user.id, weekNumber]);
 
-  const matches = weeklyMatch ? [weeklyMatch] : [];
+  if (weeklyMatches.length > 1) {
+    console.error(`⚠️ 用户 ${req.user.id} 在第 ${weekNumber} 周存在 ${weeklyMatches.length} 条正式匹配记录，页面将展示最新一条`);
+  }
+
+  const matches = weeklyMatches.length > 0 ? [weeklyMatches[0]] : [];
 
   res.render('matches', {
     title: '匹配结果',
@@ -1052,18 +1056,18 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
   });
 }));
 
-// API: 获取匹配列表
+// API: 获取实时推荐列表
 app.get('/api/matches', isLoggedIn, wrapAsync(async (req, res) => {
   const matchService = require('./matchService');
   const matches = await matchService.findMatches(req.user.id);
-  res.json({ success: true, data: matches });
+  res.json({ success: true, source: 'recommendation', data: matches });
 }));
 
-// API: 获取前5名
+// API: 获取前5名实时推荐
 app.get('/api/match/top', isLoggedIn, wrapAsync(async (req, res) => {
   const matchService = require('./matchService');
   const matches = await matchService.getTopMatches(req.user.id, 5);
-  res.json({ success: true, data: matches });
+  res.json({ success: true, source: 'recommendation', data: matches });
 }));
 
 // 管理页
@@ -1102,13 +1106,6 @@ app.post('/admin/match', isLoggedIn, requireValidCsrf, wrapAsync(async (req, res
 }));
 
 // ============ 匹配逻辑 ============
-
-function getWeekNumber() {
-  const now = new Date();
-  const start = new Date(now.getFullYear(), 0, 1);
-  const diff = now - start;
-  return Math.floor(diff / 604800000);
-}
 
 async function runWeeklyMatch() {
   const matchService = require('./matchService');

--- a/matchService.js
+++ b/matchService.js
@@ -23,6 +23,7 @@
 
 const dbModule = require('./database');
 const lovetypeService = require('./lovetypeService');
+const { getWeekNumber } = require('./weekNumber');
 
 // ============ 工具函数 ============
 
@@ -365,13 +366,6 @@ async function saveWeeklyMatches() {
   }
 
   return { success: true, message: `匹配完成，共 ${results.length} 对`, results };
-}
-
-function getWeekNumber() {
-  const now = new Date();
-  const start = new Date(now.getFullYear(), 0, 1);
-  const diff = now - start;
-  return Math.floor(diff / 604800000);
 }
 
 module.exports = {

--- a/views/matches.ejs
+++ b/views/matches.ejs
@@ -65,7 +65,7 @@
 
       <% if (matches.some(function(m) { return m.score !== null && m.score !== undefined; })) { %>
       <p style="margin-top: 24px; color: var(--muted-foreground); font-size: 0.85rem; text-align: center;">
-        💡 匹配度算法：兴趣爱好30% + 生活习惯30% + 恋爱观念40%，再结合 LoveType 兼容性做加减分
+        💡 匹配度算法：综合考虑兴趣爱好、生活习惯和恋爱观念，并结合 LoveType 兼容性做加减分
       </p>
       <% } %>
     </div>

--- a/weekNumber.js
+++ b/weekNumber.js
@@ -1,0 +1,9 @@
+function getWeekNumber(date = new Date()) {
+  const start = new Date(date.getFullYear(), 0, 1);
+  const diff = date - start;
+  return Math.floor(diff / 604800000);
+}
+
+module.exports = {
+  getWeekNumber
+};


### PR DESCRIPTION
﻿## 概要
- 抽出共享的 weekNumber 工具，避免 app.js 与 matchService.js 各自维护周号计算逻辑
- /matches 读取本周正式匹配结果时不再静默依赖 LIMIT 1；若发现同一用户同周存在多条记录，会显式打告警日志并按确定性规则展示最新一条
- /api/matches 与 /api/match/top 明确返回 source: recommendation，和 /matches 的“正式匹配结果”语义区分开
- 更新匹配页与 PROJECT.md 文案，避免继续写死过时的算法权重描述

## 验证
- `node --check app.js`
- `node --check matchService.js`

## 关联
- Closes #27
