### PR TITLE
feat: 添加每周匹配确认功能

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -176,6 +176,7 @@ shu-date/
 | verification_expire | TIMESTAMP | 注册验证 token 过期时间 |
 | reset_token | TEXT | 密码重置 token |
 | reset_token_expire | TIMESTAMP | 密码重置 token 过期时间 |
+| weekly_match_confirmed | INTEGER | 是否确认参与本周匹配（0/1） |
 | created_at | TIMESTAMP | 创建时间 |
 
 #### profiles 表
@@ -285,7 +286,8 @@ shu-date/
 | GET | /settings/delete | 注销账号页 | 已登录 |
 | POST | /settings/delete | 注销账号 | 已登录 |
 | GET | /notifications | 通知中心 | 已登录 |
-| GET | /matches | 查看本周正式匹配结果 | 已登录 |
+| GET | /confirm-match | 确认匹配页 | 已登录，需先填写问卷 |
+| GET | /matches | 查看本周正式匹配结果 | 已登录，需确认匹配 |
 | GET | /couple-match | 情侣匹配页 | 已登录 |
 | POST | /couple-match/request | 发送情侣匹配申请 | 已登录 |
 | POST | /couple-match/accept/:id | 同意匹配申请 | 已登录 |
@@ -405,6 +407,7 @@ PORT=3000
 - [x] 测试模式（无需真实邮件）
 - [x] 恋爱类型测试服务
 - [x] 统一导航栏
+- [x] 确认匹配功能（需手动确认参与本周匹配）
 
 ### 7.2 待优化事项
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -176,7 +176,8 @@ shu-date/
 | verification_expire | TIMESTAMP | 注册验证 token 过期时间 |
 | reset_token | TEXT | 密码重置 token |
 | reset_token_expire | TIMESTAMP | 密码重置 token 过期时间 |
-| weekly_match_confirmed | INTEGER | 是否确认参与本周匹配（0/1） |
+| weekly_match_year | INTEGER | 确认匹配所在年份 |
+| weekly_match_week | INTEGER | 确认匹配所在周数 |
 | created_at | TIMESTAMP | 创建时间 |
 
 #### profiles 表

--- a/app.js
+++ b/app.js
@@ -278,7 +278,7 @@ async function loadCurrentUserFromSession(req) {
   }
 
   const currentUser = await db.queryOne(`
-    SELECT id, email, nickname, name, verified
+    SELECT id, email, nickname, name, verified, weekly_match_confirmed
     FROM users
     WHERE id = $1
   `, [req.session.userId]);
@@ -302,6 +302,7 @@ async function loadCurrentUserFromSession(req) {
     name: currentUser.name,
     verified: currentUser.verified,
     hasProfile: !!profile,
+    weeklyMatchConfirmed: !!currentUser.weekly_match_confirmed,
     unreadNotifications: parseInt(unreadResult?.count || 0, 10)
   };
 
@@ -1382,6 +1383,39 @@ app.post('/settings/delete', isLoggedIn, requireValidCsrf, wrapAsync(async (req,
   });
 }));
 
+// 确认匹配页面
+app.get('/confirm-match', isLoggedIn, wrapAsync(async (req, res) => {
+  const profile = await db.queryOne('SELECT id FROM profiles WHERE user_id = $1', [req.user.id]);
+  if (!profile) {
+    return res.redirect('/profile?msg=请先填写问卷&type=warning');
+  }
+
+  res.render('confirm-match', {
+    user: req.user,
+    nickname: req.session.nickname,
+    csrfToken: ensureCsrfToken(req),
+    message: req.query.msg || '',
+    messageType: req.query.type || ''
+  });
+}));
+
+// 提交确认匹配
+app.post('/confirm-match', isLoggedIn, wrapAsync(async (req, res) => {
+  // 检查是否已有 profile
+  const profile = await db.queryOne('SELECT id FROM profiles WHERE user_id = $1', [req.user.id]);
+  if (!profile) {
+    return res.redirect('/profile?msg=请先填写问卷&type=warning');
+  }
+
+  // 更新确认状态
+  await db.execute(
+    'UPDATE users SET weekly_match_confirmed = 1 WHERE id = $1',
+    [req.user.id]
+  );
+
+  res.redirect('/?msg=已确认参与本周匹配&type=success');
+}));
+
 // 提交问卷
 app.post('/survey/submit', isLoggedIn, wrapAsync(async (req, res) => {
   const data = req.body;
@@ -1505,6 +1539,11 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
     return res.redirect('/profile');
   }
 
+  // 检查是否确认参与匹配
+  if (!req.user.weeklyMatchConfirmed) {
+    return res.redirect('/confirm-match?msg=请先确认参与本周匹配&type=warning');
+  }
+
   const weekNumber = getWeekNumber();
   const matchYear = getYear();
   const weeklyRelease = await db.queryOne(
@@ -1543,6 +1582,7 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
     weekNumber: weeklyMatches[0].week_number,
     score: weeklyMatches[0].score,
     matchedAt: weeklyMatches[0].matched_at,
+    matchId: weeklyMatches[0].id,
     partner: {
       id: weeklyMatches[0].partner_id,
       email: weeklyMatches[0].partner_email,
@@ -1551,7 +1591,8 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
       gender: weeklyMatches[0].partner_gender,
       campus: weeklyMatches[0].partner_campus,
       interests: weeklyMatches[0].partner_interests,
-      lovetype_code: weeklyMatches[0].partner_lovetype_code
+      lovetype_code: weeklyMatches[0].partner_lovetype_code,
+      score: weeklyMatches[0].score
     }
   } : null;
 
@@ -1563,6 +1604,7 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
     showPassword: true,
     weeklyMatch: weeklyMatch,
     matches: weeklyMatch ? [weeklyMatch.partner] : [],
+    matchId: weeklyMatch ? weeklyMatch.matchId : null,
     isAdmin: req.isAdmin,
     matchSource: 'weekly',
     weekNumber,
@@ -1946,6 +1988,10 @@ app.get('/couple-match/result/:id', isLoggedIn, wrapAsync(async (req, res) => {
 
 // API: 获取实时推荐列表
 app.get('/api/matches', isLoggedIn, wrapAsync(async (req, res) => {
+  // 检查是否确认参与匹配
+  if (!req.user.weeklyMatchConfirmed) {
+    return res.status(403).json({ success: false, error: '请先确认参与本周匹配' });
+  }
   const matchService = require('./matchService');
   const matches = await matchService.findMatches(req.user.id);
   res.json({ success: true, source: 'recommendation', data: matches });
@@ -1953,6 +1999,10 @@ app.get('/api/matches', isLoggedIn, wrapAsync(async (req, res) => {
 
 // API: 获取前5名实时推荐
 app.get('/api/match/top', isLoggedIn, wrapAsync(async (req, res) => {
+  // 检查是否确认参与匹配
+  if (!req.user.weeklyMatchConfirmed) {
+    return res.status(403).json({ success: false, error: '请先确认参与本周匹配' });
+  }
   const matchService = require('./matchService');
   const matches = await matchService.getTopMatches(req.user.id, 5);
   res.json({ success: true, source: 'recommendation', data: matches });
@@ -2002,6 +2052,51 @@ app.get('/api/couple-match/comment/:id', isLoggedIn, wrapAsync(async (req, res) 
   await db.execute(`
     UPDATE couple_requests SET match_score = $1, match_comment = $2, updated_at = CURRENT_TIMESTAMP WHERE id = $3
   `, [matchResult.total, comment, requestId]);
+
+  res.json({ success: true, comment, score: matchResult.total });
+}));
+
+// API: 异步获取每周匹配评语
+app.get('/api/weekly-match/comment/:id', isLoggedIn, wrapAsync(async (req, res) => {
+  const matchId = parseInt(req.params.id, 10);
+
+  const match = await db.queryOne(`
+    SELECT m.*,
+      CASE WHEN m.user_id_1 = $1 THEN m.user_id_2 ELSE m.user_id_1 END as partner_id
+    FROM matches m
+    WHERE m.id = $2 AND (m.user_id_1 = $1 OR m.user_id_2 = $1)
+  `, [req.user.id, matchId]);
+
+  if (!match) {
+    return res.status(404).json({ success: false, error: '匹配结果不存在' });
+  }
+
+  // 如果已有保存的评语则直接返回
+  if (match.match_comment) {
+    return res.json({ success: true, comment: match.match_comment, score: match.score });
+  }
+
+  // 否则重新生成
+  const profileA = await db.queryOne('SELECT * FROM profiles WHERE user_id = $1', [req.user.id]);
+  const profileB = await db.queryOne('SELECT * FROM profiles WHERE user_id = $1', [match.partner_id]);
+
+  if (!profileA || !profileB) {
+    return res.json({ success: false, error: '无法获取用户资料' });
+  }
+
+  const matchService = require('./matchService');
+  const matchResult = await matchService.getCoupleMatch(req.user.id, match.partner_id);
+
+  if (!matchResult) {
+    return res.json({ success: false, error: '无法计算匹配得分' });
+  }
+
+  const comment = await generateMatchComment(profileA, profileB, matchResult.total);
+
+  // 保存到数据库
+  await db.execute(`
+    UPDATE matches SET match_comment = $1 WHERE id = $2
+  `, [comment, matchId]);
 
   res.json({ success: true, comment, score: matchResult.total });
 }));

--- a/app.js
+++ b/app.js
@@ -278,7 +278,7 @@ async function loadCurrentUserFromSession(req) {
   }
 
   const currentUser = await db.queryOne(`
-    SELECT id, email, nickname, name, verified, weekly_match_confirmed
+    SELECT id, email, nickname, name, verified, weekly_match_year, weekly_match_week
     FROM users
     WHERE id = $1
   `, [req.session.userId]);
@@ -295,6 +295,13 @@ async function loadCurrentUserFromSession(req) {
     [currentUser.id]
   );
 
+  // 检查是否确认了本周的匹配（year + week 与当前周一致）
+  const currentYear = getYear();
+  const currentWeek = getWeekNumber();
+  const weeklyMatchConfirmed = currentUser.weekly_match_year != null
+    && currentUser.weekly_match_year === currentYear
+    && currentUser.weekly_match_week === currentWeek;
+
   const user = {
     id: currentUser.id,
     email: currentUser.email,
@@ -302,7 +309,7 @@ async function loadCurrentUserFromSession(req) {
     name: currentUser.name,
     verified: currentUser.verified,
     hasProfile: !!profile,
-    weeklyMatchConfirmed: !!currentUser.weekly_match_confirmed,
+    weeklyMatchConfirmed,
     unreadNotifications: parseInt(unreadResult?.count || 0, 10)
   };
 
@@ -432,7 +439,9 @@ function ensureCsrfToken(req) {
 }
 
 function requireValidCsrf(req, res, next) {
-  if (req.body?.csrfToken && req.session.csrfToken === req.body.csrfToken) {
+  // 兼容 _csrf（表单中常用） 和 csrfToken 两种字段名
+  const csrfToken = req.body?._csrf || req.body?.csrfToken;
+  if (csrfToken && req.session.csrfToken === csrfToken) {
     return next();
   }
 
@@ -1400,17 +1409,19 @@ app.get('/confirm-match', isLoggedIn, wrapAsync(async (req, res) => {
 }));
 
 // 提交确认匹配
-app.post('/confirm-match', isLoggedIn, wrapAsync(async (req, res) => {
+app.post('/confirm-match', isLoggedIn, requireValidCsrf, wrapAsync(async (req, res) => {
   // 检查是否已有 profile
   const profile = await db.queryOne('SELECT id FROM profiles WHERE user_id = $1', [req.user.id]);
   if (!profile) {
     return res.redirect('/profile?msg=请先填写问卷&type=warning');
   }
 
-  // 更新确认状态
+  // 更新确认状态为当前 year + week
+  const currentYear = getYear();
+  const currentWeek = getWeekNumber();
   await db.execute(
-    'UPDATE users SET weekly_match_confirmed = 1 WHERE id = $1',
-    [req.user.id]
+    'UPDATE users SET weekly_match_year = $1, weekly_match_week = $2 WHERE id = $3',
+    [currentYear, currentWeek, req.user.id]
   );
 
   res.redirect('/?msg=已确认参与本周匹配&type=success');

--- a/app.js
+++ b/app.js
@@ -2004,7 +2004,7 @@ app.get('/api/matches', isLoggedIn, wrapAsync(async (req, res) => {
     return res.status(403).json({ success: false, error: '请先确认参与本周匹配' });
   }
   const matchService = require('./matchService');
-  const matches = await matchService.findMatches(req.user.id);
+  const matches = await matchService.findMatches(req.user.id, getYear(), getWeekNumber());
   res.json({ success: true, source: 'recommendation', data: matches });
 }));
 
@@ -2015,7 +2015,7 @@ app.get('/api/match/top', isLoggedIn, wrapAsync(async (req, res) => {
     return res.status(403).json({ success: false, error: '请先确认参与本周匹配' });
   }
   const matchService = require('./matchService');
-  const matches = await matchService.getTopMatches(req.user.id, 5);
+  const matches = await matchService.getTopMatches(req.user.id, 5, getYear(), getWeekNumber());
   res.json({ success: true, source: 'recommendation', data: matches });
 }));
 

--- a/database.js
+++ b/database.js
@@ -37,6 +37,7 @@ async function initDatabase() {
   await pool.query('ALTER TABLE users ADD COLUMN IF NOT EXISTS verification_expire TIMESTAMP');
   await pool.query('ALTER TABLE users ADD COLUMN IF NOT EXISTS reset_token TEXT');
   await pool.query('ALTER TABLE users ADD COLUMN IF NOT EXISTS reset_token_expire TIMESTAMP');
+  await pool.query('ALTER TABLE users ADD COLUMN IF NOT EXISTS weekly_match_confirmed INTEGER DEFAULT 0');
   
   // profiles 表
   await pool.query(`
@@ -153,6 +154,7 @@ await pool.query(`
 
 // 为现有数据添加 match_year 列（迁移）
 await pool.query(`ALTER TABLE matches ADD COLUMN IF NOT EXISTS match_year INTEGER`);
+await pool.query(`ALTER TABLE matches ADD COLUMN IF NOT EXISTS match_comment TEXT`);
 await pool.query(`CREATE INDEX IF NOT EXISTS idx_matches_year_week ON matches (match_year, week_number)`);
 // 仅在存在旧记录时回填 match_year，避免每次启动都全表 UPDATE
 const missingMatchYear = await pool.query(`SELECT 1 FROM matches WHERE match_year IS NULL LIMIT 1`);

--- a/database.js
+++ b/database.js
@@ -37,7 +37,10 @@ async function initDatabase() {
   await pool.query('ALTER TABLE users ADD COLUMN IF NOT EXISTS verification_expire TIMESTAMP');
   await pool.query('ALTER TABLE users ADD COLUMN IF NOT EXISTS reset_token TEXT');
   await pool.query('ALTER TABLE users ADD COLUMN IF NOT EXISTS reset_token_expire TIMESTAMP');
-  await pool.query('ALTER TABLE users ADD COLUMN IF NOT EXISTS weekly_match_confirmed INTEGER DEFAULT 0');
+  // 用 year + week 组合替代单布尔字段，按周记录确认状态
+  await pool.query('ALTER TABLE users DROP COLUMN IF EXISTS weekly_match_confirmed');
+  await pool.query('ALTER TABLE users ADD COLUMN IF NOT EXISTS weekly_match_year INTEGER DEFAULT 0');
+  await pool.query('ALTER TABLE users ADD COLUMN IF NOT EXISTS weekly_match_week INTEGER DEFAULT 0');
   
   // profiles 表
   await pool.query(`

--- a/matchService.js
+++ b/matchService.js
@@ -261,19 +261,28 @@ function calculateMatchDetails(myProfile, theirProfile) {
 
 // ============ 数据库查询接口 ============
 
-async function findMatches(userId) {
+async function findMatches(userId, targetYear = null, targetWeek = null) {
   const myUser = await dbModule.queryOne('SELECT * FROM users WHERE id = $1', [userId]);
   if (!myUser) return [];
 
   const myProfile = await dbModule.queryOne('SELECT * FROM profiles WHERE user_id = $1', [userId]);
   if (!myProfile) return [];
 
+  const filters = ['u.id != $1', 'u.verified = 1'];
+  const params = [userId];
+
+  if (targetYear !== null && targetWeek !== null) {
+    params.push(targetYear, targetWeek);
+    filters.push(`u.weekly_match_year = $${params.length - 1}`);
+    filters.push(`u.weekly_match_week = $${params.length}`);
+  }
+
   const allProfiles = await dbModule.query(`
     SELECT u.id, u.email, u.nickname, u.name, p.*
     FROM users u
     JOIN profiles p ON u.id = p.user_id
-    WHERE u.id != $1 AND u.verified = 1
-  `, [userId]);
+    WHERE ${filters.join(' AND ')}
+  `, params);
 
   if (allProfiles.length === 0) return [];
 
@@ -311,8 +320,8 @@ async function findMatches(userId) {
   return scored;
 }
 
-async function getTopMatches(userId, topN = 5) {
-  const matches = await findMatches(userId);
+async function getTopMatches(userId, topN = 5, targetYear = null, targetWeek = null) {
+  const matches = await findMatches(userId, targetYear, targetWeek);
   return matches.slice(0, topN);
 }
 
@@ -330,7 +339,9 @@ async function saveWeeklyMatches(targetYear = null, targetWeek = null) {
     FROM users u
     JOIN profiles p ON u.id = p.user_id
     WHERE u.verified = 1
-  `);
+      AND u.weekly_match_year = $1
+      AND u.weekly_match_week = $2
+  `, [year, weekNumber]);
 
   if (users.length < 2) {
     return { success: false, message: '用户数量不足' };
@@ -342,7 +353,7 @@ async function saveWeeklyMatches(targetYear = null, targetWeek = null) {
   for (const user of users) {
     if (matched.has(user.id)) continue;
 
-    const matches = (await findMatches(user.id)).filter(m => !matched.has(m.user_id));
+    const matches = (await findMatches(user.id, year, weekNumber)).filter(m => !matched.has(m.user_id));
 
     if (matches.length > 0) {
       const bestMatch = matches[0];

--- a/views/confirm-match.ejs
+++ b/views/confirm-match.ejs
@@ -19,7 +19,7 @@
 
       <% if (typeof message !== 'undefined' && message) { %>
         <div class="alert alert-<%= messageType || 'info' %>" style="margin-bottom: 20px;">
-          <%- message %>
+          <%= message %>
         </div>
       <% } %>
 

--- a/views/confirm-match.ejs
+++ b/views/confirm-match.ejs
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>确认匹配 - 心有所SHU</title>
+  <link rel="stylesheet" href="/css/style.css">
+  <%- include('partials/head-icons') %>
+  <% if (typeof isDev !== 'undefined' && isDev) { %>
+  <link rel="stylesheet" href="/css/dev-tools.css">
+  <% } %>
+</head>
+<body>
+  <%- include('partials/navbar') %>
+
+  <div class="container" style="max-width: 600px; padding-top: 40px;">
+    <div class="card">
+      <h2 style="margin-bottom: 24px;">💕 确认匹配</h2>
+
+      <% if (typeof message !== 'undefined' && message) { %>
+        <div class="alert alert-<%= messageType || 'info' %>" style="margin-bottom: 20px;">
+          <%- message %>
+        </div>
+      <% } %>
+
+      <% if (user.weeklyMatchConfirmed) { %>
+        <p style="color: var(--muted-foreground); margin-bottom: 24px;">
+          你已确认参与本周匹配，无需重复确认。
+        </p>
+        <a href="/" class="btn btn-secondary">返回首页</a>
+      <% } else { %>
+        <p style="color: var(--muted-foreground); margin-bottom: 24px;">
+          点击下方按钮确认，你确定要参与本周匹配吗？确认后系统才会将你纳入本周的匹配候选池。
+        </p>
+
+        <form method="POST" action="/confirm-match">
+          <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+          <button type="submit" class="btn" style="width: 100%;">
+            确认参与本周匹配
+          </button>
+        </form>
+      <% } %>
+    </div>
+  </div>
+</body>
+</html>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -64,7 +64,11 @@
         <% } else if (user.hasProfile) { %>
           <p class="home-status__summary">资料已经提交完成，接下来等每周推荐更新，再回来看看这周系统给你的结果。</p>
           <div class="home-status__actions">
+            <% if (user.weeklyMatchConfirmed) { %>
             <a href="/matches" class="btn">看看匹配</a>
+            <% } else { %>
+            <a href="/confirm-match" class="btn">确认匹配</a>
+            <% } %>
             <a href="/profile?edit=1" class="btn btn-secondary">查看资料</a>
           </div>
         <% } else { %>
@@ -93,11 +97,18 @@
               <p><%= user.hasProfile ? '资料已经提交，偏好和性格信息都在库里。' : '补完资料后，系统才会进入匹配流程。' %></p>
             </div>
           </li>
-          <li class="home-status__step <%= user.verified && user.hasProfile ? 'is-current' : 'is-pending' %>">
-            <span class="home-status__step-badge">3</span>
+          <li class="home-status__step <%= user.verified && user.hasProfile && user.weeklyMatchConfirmed ? 'is-done' : (user.verified && user.hasProfile ? 'is-current' : 'is-pending') %>">
+            <span class="home-status__step-badge"><%= user.verified && user.hasProfile && user.weeklyMatchConfirmed ? '✓' : '3' %></span>
+            <div>
+              <strong>确认匹配</strong>
+              <p><%= user.weeklyMatchConfirmed ? '已确认参与本周匹配。' : '在此处点击确认，是否确定参见本周匹配？' %></p>
+            </div>
+          </li>
+          <li class="home-status__step <%= user.verified && user.hasProfile && user.weeklyMatchConfirmed ? 'is-current' : 'is-pending' %>">
+            <span class="home-status__step-badge">4</span>
             <div>
               <strong>查看每周推荐</strong>
-              <p><%= user.verified && user.hasProfile ? '接下来只要等每周推荐更新，就可以回来看结果。' : '完成前两步后，这里会成为你的主要入口。' %></p>
+              <p><%= user.verified && user.hasProfile && user.weeklyMatchConfirmed ? '接下来只要等每周推荐更新，就可以回来看结果。' : '完成前两步后，这里会成为你的主要入口。' %></p>
             </div>
           </li>
         </ul>


### PR DESCRIPTION
- 添加 weekly_match_confirmed 字段到 users 表
- 新增 /confirm-match 路由供用户确认参与本周匹配
- 更新主页显示第3步"确认匹配"进度
- 根据确认状态显示"确认匹配"或"看看匹配"按钮
- 在访问 /matches 页面之前先验证确认状态
- 更新 PROJECT.md 添加新路由和数据库字段
