### PR TITLE
fix: harden notifications and account deletion

### DIFF
--- a/app.js
+++ b/app.js
@@ -1335,8 +1335,10 @@ app.post('/settings/delete', isLoggedIn, requireValidCsrf, wrapAsync(async (req,
 
   try {
     await db.withTransaction(async (client) => {
-      await client.query('DELETE FROM notifications WHERE user_id = $1 OR related_user_id = $1', [userId]);
-      await client.query('DELETE FROM couple_requests WHERE requester_id = $1 OR receiver_id = $1', [userId]);
+      await client.query('DELETE FROM notifications WHERE user_id = $1', [userId]);
+      await client.query('DELETE FROM notifications WHERE related_user_id = $1', [userId]);
+      await client.query('DELETE FROM couple_requests WHERE requester_id = $1', [userId]);
+      await client.query('DELETE FROM couple_requests WHERE receiver_id = $1', [userId]);
       await client.query('DELETE FROM profiles WHERE user_id = $1', [userId]);
       await client.query('DELETE FROM matches WHERE user_id_1 = $1 OR user_id_2 = $1', [userId]);
       await client.query('DELETE FROM users WHERE id = $1', [userId]);

--- a/app.js
+++ b/app.js
@@ -1286,12 +1286,14 @@ app.get('/settings/delete', isLoggedIn, wrapAsync(async (req, res) => {
 app.post('/settings/delete', isLoggedIn, requireValidCsrf, wrapAsync(async (req, res) => {
   const { email, password } = req.body;
   const profile = await db.queryOne('SELECT * FROM profiles WHERE user_id = $1', [req.session.userId]);
+  const csrfToken = ensureCsrfToken(req);
 
   if (!email || !password) {
     return res.render('delete-account', {
       user: req.user,
       nickname: req.session.nickname,
       hasProfile: !!profile,
+      csrfToken,
       deleteMessage: '请填写邮箱和密码',
       deleteMessageType: 'error'
     });
@@ -1307,6 +1309,7 @@ app.post('/settings/delete', isLoggedIn, requireValidCsrf, wrapAsync(async (req,
       user: req.user,
       nickname: req.session.nickname,
       hasProfile: !!profile,
+      csrfToken,
       deleteMessage: '邮箱或密码错误',
       deleteMessageType: 'error'
     });
@@ -1320,34 +1323,31 @@ app.post('/settings/delete', isLoggedIn, requireValidCsrf, wrapAsync(async (req,
         user: req.user,
         nickname: req.session.nickname,
         hasProfile: !!profile,
+        csrfToken,
         deleteMessage: '邮箱或密码错误',
         deleteMessageType: 'error'
       });
     }
   }
 
-  // 删除用户数据（使用事务确保原子性）
+  // 删除用户数据（使用同一个 PostgreSQL client 保证真正原子）
   const userId = req.session.userId;
 
   try {
-    await db.execute('BEGIN');
-
-    await db.execute('DELETE FROM profiles WHERE user_id = $1', [userId]);
-    await db.execute('DELETE FROM matches WHERE user_id_1 = $1 OR user_id_2 = $1', [userId]);
-    await db.execute('DELETE FROM users WHERE id = $1', [userId]);
-
-    await db.execute('COMMIT');
+    await db.withTransaction(async (client) => {
+      await client.query('DELETE FROM notifications WHERE user_id = $1 OR related_user_id = $1', [userId]);
+      await client.query('DELETE FROM couple_requests WHERE requester_id = $1 OR receiver_id = $1', [userId]);
+      await client.query('DELETE FROM profiles WHERE user_id = $1', [userId]);
+      await client.query('DELETE FROM matches WHERE user_id_1 = $1 OR user_id_2 = $1', [userId]);
+      await client.query('DELETE FROM users WHERE id = $1', [userId]);
+    });
   } catch (error) {
-    try {
-      await db.execute('ROLLBACK');
-    } catch (rollbackError) {
-      console.error('Error rolling back account deletion transaction:', rollbackError);
-    }
-
     console.error('Error deleting user account:', error);
     return res.render('delete-account', {
+      user: req.user,
       nickname: req.session.nickname,
-      hasProfile: true,
+      hasProfile: !!profile,
+      csrfToken,
       deleteMessage: '账号注销失败，请稍后重试',
       deleteMessageType: 'error'
     });

--- a/app.js
+++ b/app.js
@@ -414,13 +414,19 @@ function ensureCsrfToken(req) {
   return req.session.csrfToken;
 }
 
-function requireValidCsrf(req, res, next) {
-  if (req.body?.csrfToken && req.session.csrfToken === req.body.csrfToken) {
-    return next();
-  }
+function createCsrfValidator(redirectTo = '/admin') {
+  return (req, res, next) => {
+    if (req.body?.csrfToken && req.session.csrfToken === req.body.csrfToken) {
+      return next();
+    }
 
-  return res.redirect('/admin?msg=' + encodeURIComponent('请求无效，请刷新页面后重试') + '&type=error');
+    const separator = redirectTo.includes('?') ? '&' : '?';
+    return res.redirect(`${redirectTo}${separator}msg=${encodeURIComponent('请求无效，请刷新页面后重试')}&type=error`);
+  };
 }
+
+const requireValidCsrf = createCsrfValidator('/admin');
+const requireValidDeleteCsrf = createCsrfValidator('/settings/delete');
 
 function renderSafely(res, status, view, locals = {}, fallbackMessage = '页面暂时不可用') {
   res.status(status).render(view, locals, (renderErr, html) => {
@@ -1278,12 +1284,14 @@ app.get('/settings/delete', isLoggedIn, wrapAsync(async (req, res) => {
     user: req.user,
     nickname: req.session.nickname,
     hasProfile: !!profile,
-    csrfToken: ensureCsrfToken(req)
+    csrfToken: ensureCsrfToken(req),
+    deleteMessage: req.query.msg || '',
+    deleteMessageType: req.query.type || ''
   });
 }));
 
 // 注销账号
-app.post('/settings/delete', isLoggedIn, requireValidCsrf, wrapAsync(async (req, res) => {
+app.post('/settings/delete', isLoggedIn, requireValidDeleteCsrf, wrapAsync(async (req, res) => {
   const { email, password } = req.body;
   const profile = await db.queryOne('SELECT * FROM profiles WHERE user_id = $1', [req.session.userId]);
   const csrfToken = ensureCsrfToken(req);

--- a/database.js
+++ b/database.js
@@ -233,12 +233,37 @@ async function execute(sql, params = []) {
   return { changes: result.rowCount, lastInsertRowid: null };
 }
 
+async function getClient() {
+  return pool.connect();
+}
+
+async function withTransaction(callback) {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const result = await callback(client);
+    await client.query('COMMIT');
+    return result;
+  } catch (error) {
+    try {
+      await client.query('ROLLBACK');
+    } catch (rollbackError) {
+      console.error('Transaction rollback failed:', rollbackError);
+    }
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
 module.exports = {
   SESSION_TABLE_NAME,
   initDatabase,
   query,
   queryOne,
   execute,
+  getClient,
+  withTransaction,
   init: initDatabase,
   getPool: () => pool
 };

--- a/database.js
+++ b/database.js
@@ -189,6 +189,8 @@ await pool.query(`
 // 迁移：为已存在的 couple_requests 表添加新字段
 await pool.query(`ALTER TABLE couple_requests ADD COLUMN IF NOT EXISTS match_score NUMERIC(5,2)`);
 await pool.query(`ALTER TABLE couple_requests ADD COLUMN IF NOT EXISTS match_comment TEXT`);
+await pool.query(`CREATE INDEX IF NOT EXISTS idx_couple_requests_requester_id ON couple_requests (requester_id)`);
+await pool.query(`CREATE INDEX IF NOT EXISTS idx_couple_requests_receiver_id ON couple_requests (receiver_id)`);
 
 // 通知表
 await pool.query(`
@@ -209,6 +211,7 @@ await pool.query(`
 
 await pool.query(`CREATE INDEX IF NOT EXISTS idx_notifications_user_id ON notifications (user_id)`);
 await pool.query(`CREATE INDEX IF NOT EXISTS idx_notifications_user_unread ON notifications (user_id, is_read)`);
+await pool.query(`CREATE INDEX IF NOT EXISTS idx_notifications_related_user_id ON notifications (related_user_id)`);
 
   isInitialized = true;
   console.log('✅ Supabase PostgreSQL 数据库初始化完成');

--- a/views/notifications.ejs
+++ b/views/notifications.ejs
@@ -19,7 +19,7 @@
 
       <% if (typeof message !== 'undefined' && message) { %>
         <div class="alert alert-<%= messageType || 'info' %>" style="margin-bottom: 20px;">
-          <%- message %>
+          <%= message %>
         </div>
       <% } %>
 

--- a/views/notifications.ejs
+++ b/views/notifications.ejs
@@ -29,7 +29,7 @@
             <div class="notification-item" style="padding: 16px; border-bottom: 1px solid var(--border); <% if (!notification.is_read) { %>background: var(--accent);<% } %>">
               <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                  <p style="margin: 0 0 8px 0;"><%- notification.content %></p>
+                  <p style="margin: 0 0 8px 0;"><%= notification.content %></p>
                   <p style="margin: 0; font-size: 12px; color: var(--muted-foreground);">
                     <%= new Date(notification.created_at).toLocaleString('zh-CN') %>
                   </p>


### PR DESCRIPTION
﻿## 概要
- 修复通知中心未转义渲染通知内容导致的存储型 XSS
- 将账号注销流程改为真正使用同一个 PostgreSQL client 的事务
- 顺手补齐注销时的关联数据删除和错误回显字段

## 变更
- `views/notifications.ejs`
  - 将通知内容渲染改为转义输出，避免昵称等用户可控内容进入 HTML 执行
- `database.js`
  - 新增 `withTransaction()`，显式使用同一个 client 执行事务
- `app.js`
  - 账号注销改为走 `db.withTransaction(...)`
  - 注销时同时删除 `notifications` 和 `couple_requests`，避免外键残留
  - 注销失败回显时补上 `csrfToken`

## 验证
- `node --check app.js`
- `node --check database.js`

Closes #116
Closes #117
