### PR TITLE
ci：补充最小版 GitHub Actions 检查

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,21 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   syntax-check:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # actions/checkout v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        # actions/setup-node v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  syntax-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check app.js syntax
+        run: node --check app.js
+
+      - name: Check database.js syntax
+        run: node --check database.js
+
+      - name: Check matchService.js syntax
+        run: node --check matchService.js


### PR DESCRIPTION
## 概要
- 新增最小版 GitHub Actions CI workflow
- 在 push 到 main 和 pull_request 时自动运行
- 安装依赖并检查 app.js / database.js / matchService.js 的语法

## 背景
当前仓库已经有持续的 PR 协作，但还没有最基本的自动检查。这条 PR 先补一版最小可行 CI，用来尽早拦住明显的语法或依赖层面问题。

## 验证
- 本地检查 workflow 文件内容
- CI 触发后将自动执行 npm ci 和三个 node --check
