### PR TITLE
perf：为静态资源补充缓存头

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,8 @@ const BCRYPT_ROUNDS = 10;
 const SESSION_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const SESSION_PRUNE_INTERVAL_SECONDS = 15 * 60;
 const SESSION_TABLE_NAME = dbModule.SESSION_TABLE_NAME;
+const ONE_DAY_SECONDS = 60 * 60 * 24;
+const SEVEN_DAYS_SECONDS = ONE_DAY_SECONDS * 7;
 
 // 密码哈希函数 - 使用 bcrypt
 async function hashPassword(password) {
@@ -210,7 +212,22 @@ app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json()); // 支持 JSON body (cron 服务可能使用 application/json)
-app.use(express.static(path.join(__dirname, 'public')));
+app.use(express.static(path.join(__dirname, 'public'), {
+  etag: true,
+  lastModified: true,
+  setHeaders(res, filePath) {
+    const ext = path.extname(filePath).toLowerCase();
+
+    if (['.jpg', '.jpeg', '.png', '.webp', '.avif', '.gif', '.svg', '.ico'].includes(ext)) {
+      res.setHeader('Cache-Control', `public, max-age=${SEVEN_DAYS_SECONDS}`);
+      return;
+    }
+
+    if (['.css', '.js', '.woff', '.woff2', '.ttf', '.otf'].includes(ext)) {
+      res.setHeader('Cache-Control', `public, max-age=${ONE_DAY_SECONDS}`);
+    }
+  }
+}));
 app.use(session({
   store: new PgSession({
     pool: dbModule.getPool(),

--- a/app.js
+++ b/app.js
@@ -17,8 +17,8 @@ const BCRYPT_ROUNDS = 10;
 const SESSION_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const SESSION_PRUNE_INTERVAL_SECONDS = 15 * 60;
 const SESSION_TABLE_NAME = dbModule.SESSION_TABLE_NAME;
-const ONE_DAY_SECONDS = 60 * 60 * 24;
-const SEVEN_DAYS_SECONDS = ONE_DAY_SECONDS * 7;
+const TEN_MINUTES_SECONDS = 60 * 10;
+const ONE_HOUR_SECONDS = 60 * 60;
 
 // 密码哈希函数 - 使用 bcrypt
 async function hashPassword(password) {
@@ -219,12 +219,12 @@ app.use(express.static(path.join(__dirname, 'public'), {
     const ext = path.extname(filePath).toLowerCase();
 
     if (['.jpg', '.jpeg', '.png', '.webp', '.avif', '.gif', '.svg', '.ico'].includes(ext)) {
-      res.setHeader('Cache-Control', `public, max-age=${SEVEN_DAYS_SECONDS}`);
+      res.setHeader('Cache-Control', `public, max-age=${ONE_HOUR_SECONDS}`);
       return;
     }
 
     if (['.css', '.js', '.woff', '.woff2', '.ttf', '.otf'].includes(ext)) {
-      res.setHeader('Cache-Control', `public, max-age=${ONE_DAY_SECONDS}`);
+      res.setHeader('Cache-Control', `public, max-age=${TEN_MINUTES_SECONDS}`);
     }
   }
 }));


### PR DESCRIPTION
## 概要
- 为 public/ 下的静态资源补充缓存头
- 让首页 Hero 使用的 campus.jpg 能被浏览器本地缓存
- 不改 HTML 页面本身的缓存策略

## 变更
- 图片资源（jpg/png/webp/avif/gif/svg/ico）设置为 1 小时缓存
- CSS / JS / 字体资源设置为 10 分钟缓存
- 保留 etag 和 lastModified

## 背景
当前首页背景图已经是本地静态文件，但 express.static 没有显式缓存策略。这样浏览器虽然可能做默认协商缓存，但不会是比较稳定的本地缓存行为。

## 验证
- 
ode --check app.js
