### PR TITLE
feat: add classic dark mode foundation

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -6,12 +6,16 @@
   --primary: #e85a5a;
   --primary-hover: #d44a4a;
   --primary-light: #fef2f2;
+  --accent: #fdf2f2;
+  --accent-foreground: #6b1f1f;
 
   /* 背景色 */
   --background: #fafafa;
   --foreground: #1a1a1a;
   --muted: #f5f5f5;
   --muted-foreground: #737373;
+  --surface-soft: #f8f9fa;
+  --surface-elevated: #ffffff;
 
   /* 卡片 */
   --card: #ffffff;
@@ -21,11 +25,34 @@
   --border: #e5e5e5;
   --input: #e5e5e5;
   --ring: #e85a5a;
+  --navbar-bg: rgba(255, 255, 255, 0.9);
 
   /* 功能色 */
   --success: #22c55e;
   --error: #ef4444;
   --info: #3b82f6;
+  --success-bg: #dcfce7;
+  --success-foreground: #166534;
+  --success-border: #86efac;
+  --error-bg: #fee2e2;
+  --error-foreground: #991b1b;
+  --error-border: #fca5a5;
+  --info-bg: #dbeafe;
+  --info-foreground: #1e40af;
+  --info-border: #93c5fd;
+  --warning: #f59e0b;
+  --warning-bg: #fff3cd;
+  --warning-foreground: #856404;
+  --warning-border: #ffc107;
+
+  /* 组件语义 */
+  --hero-button-bg: #ffffff;
+  --hero-button-foreground: var(--primary);
+  --hero-button-hover: #fafafa;
+  --match-card-bg: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
+  --match-info-bg: #ffffff;
+  --table-bg: #ffffff;
+  --table-row-hover: var(--muted);
 
   /* 圆角 */
   --radius: 12px;
@@ -36,6 +63,61 @@
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
   --shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
   --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --primary: #f16f6f;
+    --primary-hover: #ff8e8e;
+    --primary-light: rgba(241, 111, 111, 0.14);
+    --accent: rgba(241, 111, 111, 0.12);
+    --accent-foreground: #ffd8d8;
+
+    --background: #09111f;
+    --foreground: #eef3ff;
+    --muted: #121c2d;
+    --muted-foreground: #9fb0ca;
+    --surface-soft: #111a29;
+    --surface-elevated: #172236;
+
+    --card: #0f1728;
+    --card-foreground: #f5f8ff;
+
+    --border: #22324c;
+    --input: #31415d;
+    --ring: #f16f6f;
+    --navbar-bg: rgba(9, 17, 31, 0.84);
+
+    --success-bg: rgba(34, 197, 94, 0.16);
+    --success-foreground: #9df0b8;
+    --success-border: rgba(34, 197, 94, 0.28);
+    --error-bg: rgba(239, 68, 68, 0.16);
+    --error-foreground: #ffc2c2;
+    --error-border: rgba(239, 68, 68, 0.3);
+    --info-bg: rgba(59, 130, 246, 0.16);
+    --info-foreground: #b9d4ff;
+    --info-border: rgba(59, 130, 246, 0.28);
+    --warning: #f7b955;
+    --warning-bg: rgba(245, 158, 11, 0.16);
+    --warning-foreground: #ffd99a;
+    --warning-border: rgba(245, 158, 11, 0.3);
+
+    --hero-button-bg: #f4f6fb;
+    --hero-button-foreground: #12203a;
+    --hero-button-hover: #ffffff;
+    --match-card-bg: linear-gradient(135deg, rgba(241, 111, 111, 0.22) 0%, rgba(241, 111, 111, 0.1) 100%);
+    --match-info-bg: #111a29;
+    --table-bg: #0f1728;
+    --table-row-hover: rgba(255, 255, 255, 0.04);
+
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+    --shadow: 0 8px 18px rgba(0, 0, 0, 0.28);
+    --shadow-lg: 0 18px 36px rgba(0, 0, 0, 0.34);
+  }
+
+  body {
+    color-scheme: dark;
+  }
 }
 
 /* ===== 基础重置 ===== */
@@ -68,7 +150,7 @@ body {
   top: 0;
   z-index: 100;
   backdrop-filter: blur(10px);
-  background: rgba(255, 255, 255, 0.9);
+  background: var(--navbar-bg);
 }
 
 .navbar .container {
@@ -275,21 +357,21 @@ body {
 }
 
 .alert-success {
-  background: #dcfce7;
-  color: #166534;
-  border-color: #86efac;
+  background: var(--success-bg);
+  color: var(--success-foreground);
+  border-color: var(--success-border);
 }
 
 .alert-error {
-  background: #fee2e2;
-  color: #991b1b;
-  border-color: #fca5a5;
+  background: var(--error-bg);
+  color: var(--error-foreground);
+  border-color: var(--error-border);
 }
 
 .alert-info {
-  background: #dbeafe;
-  color: #1e40af;
-  border-color: #93c5fd;
+  background: var(--info-bg);
+  color: var(--info-foreground);
+  border-color: var(--info-border);
 }
 
 /* ===== 首页 Hero ===== */
@@ -337,8 +419,8 @@ body {
 }
 
 .hero .btn {
-  background: white;
-  color: var(--primary);
+  background: var(--hero-button-bg);
+  color: var(--hero-button-foreground);
   font-weight: 600;
   margin-top: 16px;
   position: relative;
@@ -346,7 +428,7 @@ body {
 }
 
 .hero .btn:hover {
-  background: #fafafa;
+  background: var(--hero-button-hover);
   transform: translateY(-2px);
 }
 
@@ -551,7 +633,7 @@ body {
 
 /* ===== 匹配结果 ===== */
 .match-card {
-  background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
+  background: var(--match-card-bg);
   padding: 32px;
   border-radius: var(--radius-lg);
   text-align: center;
@@ -565,7 +647,7 @@ body {
 }
 
 .match-info {
-  background: white;
+  background: var(--match-info-bg);
   padding: 24px;
   border-radius: var(--radius);
   margin: 20px 0;
@@ -594,7 +676,7 @@ body {
 table {
   width: 100%;
   border-collapse: collapse;
-  background: white;
+  background: var(--table-bg);
 }
 
 th, td {
@@ -617,7 +699,16 @@ tr:last-child td {
 }
 
 tr:hover td {
-  background: var(--muted);
+  background: var(--table-row-hover);
+}
+
+.btn-danger {
+  background: var(--error);
+  color: white;
+}
+
+.btn-danger:hover {
+  background: #dc2626;
 }
 
 /* ===== 页脚 ===== */

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -65,8 +65,62 @@
   --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
 }
 
+:root[data-theme="light"] {
+  color-scheme: light;
+}
+
+:root[data-theme="dark"] {
+  --primary: #f16f6f;
+  --primary-hover: #ff8e8e;
+  --primary-light: rgba(241, 111, 111, 0.14);
+  --accent: rgba(241, 111, 111, 0.12);
+  --accent-foreground: #ffd8d8;
+
+  --background: #09111f;
+  --foreground: #eef3ff;
+  --muted: #121c2d;
+  --muted-foreground: #9fb0ca;
+  --surface-soft: #111a29;
+  --surface-elevated: #172236;
+
+  --card: #0f1728;
+  --card-foreground: #f5f8ff;
+
+  --border: #22324c;
+  --input: #31415d;
+  --ring: #f16f6f;
+  --navbar-bg: rgba(9, 17, 31, 0.84);
+
+  --success-bg: rgba(34, 197, 94, 0.16);
+  --success-foreground: #9df0b8;
+  --success-border: rgba(34, 197, 94, 0.28);
+  --error-bg: rgba(239, 68, 68, 0.16);
+  --error-foreground: #ffc2c2;
+  --error-border: rgba(239, 68, 68, 0.3);
+  --info-bg: rgba(59, 130, 246, 0.16);
+  --info-foreground: #b9d4ff;
+  --info-border: rgba(59, 130, 246, 0.28);
+  --warning: #f7b955;
+  --warning-bg: rgba(245, 158, 11, 0.16);
+  --warning-foreground: #ffd99a;
+  --warning-border: rgba(245, 158, 11, 0.3);
+
+  --hero-button-bg: #f4f6fb;
+  --hero-button-foreground: #12203a;
+  --hero-button-hover: #ffffff;
+  --match-card-bg: linear-gradient(135deg, rgba(241, 111, 111, 0.22) 0%, rgba(241, 111, 111, 0.1) 100%);
+  --match-info-bg: #111a29;
+  --table-bg: #0f1728;
+  --table-row-hover: rgba(255, 255, 255, 0.04);
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow: 0 8px 18px rgba(0, 0, 0, 0.28);
+  --shadow-lg: 0 18px 36px rgba(0, 0, 0, 0.34);
+  color-scheme: dark;
+}
+
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme]) {
     --primary: #f16f6f;
     --primary-hover: #ff8e8e;
     --primary-light: rgba(241, 111, 111, 0.14);
@@ -113,9 +167,6 @@
     --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
     --shadow: 0 8px 18px rgba(0, 0, 0, 0.28);
     --shadow-lg: 0 18px 36px rgba(0, 0, 0, 0.34);
-  }
-
-  body {
     color-scheme: dark;
   }
 }
@@ -176,6 +227,38 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.theme-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--muted);
+}
+
+.theme-switch__button {
+  border: none;
+  background: transparent;
+  color: var(--muted-foreground);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.theme-switch__button:hover {
+  color: var(--foreground);
+}
+
+.theme-switch__button.is-active {
+  background: var(--card);
+  color: var(--foreground);
+  box-shadow: var(--shadow-sm);
 }
 
 .nav-links a {
@@ -826,6 +909,15 @@ tr:hover td {
 
   .nav-links > a:not(.btn) {
     display: none;
+  }
+
+  .theme-switch {
+    padding: 3px;
+  }
+
+  .theme-switch__button {
+    padding: 6px 10px;
+    font-size: 0.76rem;
   }
 
   /* 移动端下拉菜单里的链接要显示 */

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -198,7 +198,6 @@ body {
 
 /* ===== 导航栏 ===== */
 .navbar {
-  background: var(--card);
   border-bottom: 1px solid var(--border);
   position: sticky;
   top: 0;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -37,6 +37,7 @@
   --error-bg: #fee2e2;
   --error-foreground: #991b1b;
   --error-border: #fca5a5;
+  --error-hover: #dc2626;
   --info-bg: #dbeafe;
   --info-foreground: #1e40af;
   --info-border: #93c5fd;
@@ -97,6 +98,7 @@
   --error-bg: rgba(239, 68, 68, 0.16);
   --error-foreground: #ffc2c2;
   --error-border: rgba(239, 68, 68, 0.3);
+  --error-hover: #f87171;
   --info-bg: rgba(59, 130, 246, 0.16);
   --info-foreground: #b9d4ff;
   --info-border: rgba(59, 130, 246, 0.28);
@@ -148,6 +150,7 @@
     --error-bg: rgba(239, 68, 68, 0.16);
     --error-foreground: #ffc2c2;
     --error-border: rgba(239, 68, 68, 0.3);
+    --error-hover: #f87171;
     --info-bg: rgba(59, 130, 246, 0.16);
     --info-foreground: #b9d4ff;
     --info-border: rgba(59, 130, 246, 0.28);
@@ -791,7 +794,7 @@ tr:hover td {
 }
 
 .btn-danger:hover {
-  background: #dc2626;
+  background: var(--error-hover);
 }
 
 /* ===== 页脚 ===== */

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -19,9 +19,9 @@
         <a href="/matches">匹配结果</a>
         <a href="/admin" style="color: var(--primary); font-weight: 600;">管理</a>
         <div class="theme-switch" role="group" aria-label="主题切换">
-          <button type="button" class="theme-switch__button" data-theme-option="system">系统</button>
-          <button type="button" class="theme-switch__button" data-theme-option="light">浅色</button>
-          <button type="button" class="theme-switch__button" data-theme-option="dark">深色</button>
+          <button type="button" class="theme-switch__button" data-theme-option="system" aria-pressed="false">系统</button>
+          <button type="button" class="theme-switch__button" data-theme-option="light" aria-pressed="false">浅色</button>
+          <button type="button" class="theme-switch__button" data-theme-option="dark" aria-pressed="false">深色</button>
         </div>
         <a href="/logout" class="btn">退出</a>
       </div>
@@ -115,67 +115,5 @@
   <% if (typeof isDev !== 'undefined' && isDev) { %>
   <%- include('partials/dev-tools') %>
   <% } %>
-  <script>
-  (function() {
-    var media = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
-
-    function getStoredTheme() {
-      try {
-        return localStorage.getItem('shu-theme');
-      } catch (e) {
-        return null;
-      }
-    }
-
-    function applyTheme(theme) {
-      var root = document.documentElement;
-      if (theme === 'light' || theme === 'dark') {
-        root.setAttribute('data-theme', theme);
-      } else {
-        root.removeAttribute('data-theme');
-      }
-    }
-
-    function markThemeButtons() {
-      var current = getStoredTheme() || 'system';
-      document.querySelectorAll('[data-theme-option]').forEach(function(button) {
-        button.classList.toggle('is-active', button.getAttribute('data-theme-option') === current);
-      });
-    }
-
-    document.addEventListener('click', function(e) {
-      var button = e.target.closest('[data-theme-option]');
-      if (!button) return;
-      var theme = button.getAttribute('data-theme-option');
-      try {
-        if (theme === 'system') {
-          localStorage.removeItem('shu-theme');
-        } else {
-          localStorage.setItem('shu-theme', theme);
-        }
-      } catch (err) {}
-      applyTheme(theme);
-      markThemeButtons();
-    });
-
-    if (media && typeof media.addEventListener === 'function') {
-      media.addEventListener('change', function() {
-        if (!getStoredTheme()) {
-          applyTheme('system');
-          markThemeButtons();
-        }
-      });
-    } else if (media && typeof media.addListener === 'function') {
-      media.addListener(function() {
-        if (!getStoredTheme()) {
-          applyTheme('system');
-          markThemeButtons();
-        }
-      });
-    }
-
-    markThemeButtons();
-  })();
-  </script>
 </body>
 </html>

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -75,7 +75,7 @@
               <span style="color: var(--primary);">强制重跑 (删除已有记录)</span>
             </label>
           </div>
-          <button type="submit" class="btn" style="background: var(--warning); color: #111827;">▶️ 执行补跑</button>
+          <button type="submit" class="btn" style="background: var(--warning); color: var(--warning-foreground);">▶️ 执行补跑</button>
         </form>
       </div>
 

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -31,46 +31,46 @@
     <div class="card">
       <h2>👥 用户管理</h2>
 
-      <div style="margin-bottom: 20px; padding: 15px; background: #fff3e0; border-radius: 8px; border-left: 4px solid #3498db;">
-        <h4 style="margin: 0 0 10px 0; color: #3498db;">🔄 手动触发本周匹配</h4>
+      <div style="margin-bottom: 20px; padding: 15px; background: var(--info-bg); border-radius: 8px; border-left: 4px solid var(--info);">
+        <h4 style="margin: 0 0 10px 0; color: var(--info-foreground);">🔄 手动触发本周匹配</h4>
         <form action="/admin/match" method="POST" style="display: flex; gap: 10px; align-items: center; flex-wrap: wrap;">
           <input type="hidden" name="csrfToken" value="<%= csrfToken %>">
           <div>
-            <label style="font-size: 14px; color: #666;">确认密码：</label>
+            <label style="font-size: 14px; color: var(--muted-foreground);">确认密码：</label>
             <input type="password" name="confirmPassword" placeholder="请输入您的密码" required
-                   style="padding: 8px 12px; border: 1px solid #ddd; border-radius: 4px; width: 150px;">
+                   style="padding: 8px 12px; border: 1px solid var(--input); border-radius: 4px; width: 150px; background: var(--card); color: var(--foreground);">
           </div>
           <button type="submit" class="btn">🔄 执行匹配</button>
         </form>
-        <span style="margin-left: 15px; color: #666; font-size: 12px;">当前第 <%= weekNumber %> 周</span>
+        <span style="margin-left: 15px; color: var(--muted-foreground); font-size: 12px;">当前第 <%= weekNumber %> 周</span>
       </div>
 
-      <div style="margin-bottom: 20px; padding: 15px; background: #f8f9fa; border-radius: 8px; border-left: 4px solid #f39c12;">
-        <h4 style="margin: 0 0 10px 0; color: #f39c12;">🔧 补跑匹配</h4>
+      <div style="margin-bottom: 20px; padding: 15px; background: var(--surface-soft); border-radius: 8px; border-left: 4px solid var(--warning);">
+        <h4 style="margin: 0 0 10px 0; color: var(--warning);">🔧 补跑匹配</h4>
         <form action="/admin/match/rerun" method="POST" style="display: flex; gap: 10px; align-items: center; flex-wrap: wrap;">
           <input type="hidden" name="csrfToken" value="<%= csrfToken %>">
           <div>
-            <label style="font-size: 14px; color: #666;">目标年份：</label>
+            <label style="font-size: 14px; color: var(--muted-foreground);">目标年份：</label>
             <input type="number" name="targetYear" placeholder="留空=当前年" min="2020" max="2100"
-                   style="padding: 8px 12px; border: 1px solid #ddd; border-radius: 4px; width: 100px;">
+                   style="padding: 8px 12px; border: 1px solid var(--input); border-radius: 4px; width: 100px; background: var(--card); color: var(--foreground);">
           </div>
           <div>
-            <label style="font-size: 14px; color: #666;">目标周数：</label>
+            <label style="font-size: 14px; color: var(--muted-foreground);">目标周数：</label>
             <input type="number" name="targetWeek" placeholder="留空=当前周（0 起始）" min="0" max="53"
-                   style="padding: 8px 12px; border: 1px solid #ddd; border-radius: 4px; width: 100px;">
+                   style="padding: 8px 12px; border: 1px solid var(--input); border-radius: 4px; width: 100px; background: var(--card); color: var(--foreground);">
           </div>
           <div>
-            <label style="font-size: 14px; color: #666;">确认密码：</label>
+            <label style="font-size: 14px; color: var(--muted-foreground);">确认密码：</label>
             <input type="password" name="confirmPassword" placeholder="请输入密码确认" required
-                   style="padding: 8px 12px; border: 1px solid #ddd; border-radius: 4px; width: 150px;">
+                   style="padding: 8px 12px; border: 1px solid var(--input); border-radius: 4px; width: 150px; background: var(--card); color: var(--foreground);">
           </div>
           <div>
             <label style="font-size: 14px; display: flex; align-items: center; gap: 5px;">
               <input type="checkbox" name="force" value="true">
-              <span style="color: #e74c3c;">强制重跑 (删除已有记录)</span>
+              <span style="color: var(--primary);">强制重跑 (删除已有记录)</span>
             </label>
           </div>
-          <button type="submit" class="btn" style="background: #f39c12;">▶️ 执行补跑</button>
+          <button type="submit" class="btn" style="background: var(--warning); color: #111827;">▶️ 执行补跑</button>
         </form>
       </div>
 
@@ -99,7 +99,7 @@
         </tbody>
       </table>
 
-      <p style="margin-top: 20px; color: #666;">
+      <p style="margin-top: 20px; color: var(--muted-foreground);">
         共 <%= users.length %> 位用户注册
       </p>
     </div>

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -18,6 +18,11 @@
         <a href="/profile">我的资料</a>
         <a href="/matches">匹配结果</a>
         <a href="/admin" style="color: var(--primary); font-weight: 600;">管理</a>
+        <div class="theme-switch" role="group" aria-label="主题切换">
+          <button type="button" class="theme-switch__button" data-theme-option="system">系统</button>
+          <button type="button" class="theme-switch__button" data-theme-option="light">浅色</button>
+          <button type="button" class="theme-switch__button" data-theme-option="dark">深色</button>
+        </div>
         <a href="/logout" class="btn">退出</a>
       </div>
     </div>
@@ -110,5 +115,67 @@
   <% if (typeof isDev !== 'undefined' && isDev) { %>
   <%- include('partials/dev-tools') %>
   <% } %>
+  <script>
+  (function() {
+    var media = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+
+    function getStoredTheme() {
+      try {
+        return localStorage.getItem('shu-theme');
+      } catch (e) {
+        return null;
+      }
+    }
+
+    function applyTheme(theme) {
+      var root = document.documentElement;
+      if (theme === 'light' || theme === 'dark') {
+        root.setAttribute('data-theme', theme);
+      } else {
+        root.removeAttribute('data-theme');
+      }
+    }
+
+    function markThemeButtons() {
+      var current = getStoredTheme() || 'system';
+      document.querySelectorAll('[data-theme-option]').forEach(function(button) {
+        button.classList.toggle('is-active', button.getAttribute('data-theme-option') === current);
+      });
+    }
+
+    document.addEventListener('click', function(e) {
+      var button = e.target.closest('[data-theme-option]');
+      if (!button) return;
+      var theme = button.getAttribute('data-theme-option');
+      try {
+        if (theme === 'system') {
+          localStorage.removeItem('shu-theme');
+        } else {
+          localStorage.setItem('shu-theme', theme);
+        }
+      } catch (err) {}
+      applyTheme(theme);
+      markThemeButtons();
+    });
+
+    if (media && typeof media.addEventListener === 'function') {
+      media.addEventListener('change', function() {
+        if (!getStoredTheme()) {
+          applyTheme('system');
+          markThemeButtons();
+        }
+      });
+    } else if (media && typeof media.addListener === 'function') {
+      media.addListener(function() {
+        if (!getStoredTheme()) {
+          applyTheme('system');
+          markThemeButtons();
+        }
+      });
+    }
+
+    markThemeButtons();
+  })();
+  </script>
 </body>
 </html>

--- a/views/couple-match.ejs
+++ b/views/couple-match.ejs
@@ -68,7 +68,7 @@
                   <%= new Date(req.created_at).toLocaleString('zh-CN') %>
                 </p>
               </div>
-              <span style="padding: 4px 8px; font-size: 12px; border-radius: 4px; <% if (req.status === 'pending') { %>background: var(--accent);<% } else if (req.status === 'accepted') { %>background: #dcfce7; color: #166534;<% } else if (req.status === 'rejected') { %>background: #fee2e2; color: #991b1b;<% } %>">
+                <span style="padding: 4px 8px; font-size: 12px; border-radius: 4px; <% if (req.status === 'pending') { %>background: var(--accent); color: var(--accent-foreground);<% } else if (req.status === 'accepted') { %>background: var(--success-bg); color: var(--success-foreground); border: 1px solid var(--success-border);<% } else if (req.status === 'rejected') { %>background: var(--error-bg); color: var(--error-foreground); border: 1px solid var(--error-border);<% } %>">
                 <% if (req.status === 'pending') { %>待回复<% } else if (req.status === 'accepted') { %>已同意<% } else if (req.status === 'rejected') { %>已拒绝<% } %>
               </span>
             </div>
@@ -90,7 +90,7 @@
               <% if (req.status === 'pending') { %>
                 <span style="color: var(--muted-foreground); font-size: 12px;">请在通知中心处理</span>
               <% } else { %>
-                <span style="padding: 4px 8px; font-size: 12px; border-radius: 4px; <% if (req.status === 'accepted') { %>background: #dcfce7; color: #166534;<% } else if (req.status === 'rejected') { %>background: #fee2e2; color: #991b1b;<% } %>">
+                <span style="padding: 4px 8px; font-size: 12px; border-radius: 4px; <% if (req.status === 'accepted') { %>background: var(--success-bg); color: var(--success-foreground); border: 1px solid var(--success-border);<% } else if (req.status === 'rejected') { %>background: var(--error-bg); color: var(--error-foreground); border: 1px solid var(--error-border);<% } %>">
                   <% if (req.status === 'accepted') { %>已同意<% } else if (req.status === 'rejected') { %>已拒绝<% } %>
                 </span>
               <% } %>

--- a/views/couple-match.ejs
+++ b/views/couple-match.ejs
@@ -68,7 +68,7 @@
                   <%= new Date(req.created_at).toLocaleString('zh-CN') %>
                 </p>
               </div>
-                <span style="padding: 4px 8px; font-size: 12px; border-radius: 4px; <% if (req.status === 'pending') { %>background: var(--accent); color: var(--accent-foreground);<% } else if (req.status === 'accepted') { %>background: var(--success-bg); color: var(--success-foreground); border: 1px solid var(--success-border);<% } else if (req.status === 'rejected') { %>background: var(--error-bg); color: var(--error-foreground); border: 1px solid var(--error-border);<% } %>">
+                <span style="padding: 4px 8px; font-size: 12px; border-radius: 4px; border: 1px solid transparent; box-sizing: border-box; <% if (req.status === 'pending') { %>background: var(--accent); color: var(--accent-foreground);<% } else if (req.status === 'accepted') { %>background: var(--success-bg); color: var(--success-foreground); border-color: var(--success-border);<% } else if (req.status === 'rejected') { %>background: var(--error-bg); color: var(--error-foreground); border-color: var(--error-border);<% } %>">
                 <% if (req.status === 'pending') { %>待回复<% } else if (req.status === 'accepted') { %>已同意<% } else if (req.status === 'rejected') { %>已拒绝<% } %>
               </span>
             </div>
@@ -90,7 +90,7 @@
               <% if (req.status === 'pending') { %>
                 <span style="color: var(--muted-foreground); font-size: 12px;">请在通知中心处理</span>
               <% } else { %>
-                <span style="padding: 4px 8px; font-size: 12px; border-radius: 4px; <% if (req.status === 'accepted') { %>background: var(--success-bg); color: var(--success-foreground); border: 1px solid var(--success-border);<% } else if (req.status === 'rejected') { %>background: var(--error-bg); color: var(--error-foreground); border: 1px solid var(--error-border);<% } %>">
+                <span style="padding: 4px 8px; font-size: 12px; border-radius: 4px; border: 1px solid transparent; box-sizing: border-box; <% if (req.status === 'accepted') { %>background: var(--success-bg); color: var(--success-foreground); border-color: var(--success-border);<% } else if (req.status === 'rejected') { %>background: var(--error-bg); color: var(--error-foreground); border-color: var(--error-border);<% } %>">
                   <% if (req.status === 'accepted') { %>已同意<% } else if (req.status === 'rejected') { %>已拒绝<% } %>
                 </span>
               <% } %>

--- a/views/delete-account.ejs
+++ b/views/delete-account.ejs
@@ -11,11 +11,11 @@
   <%- include('partials/navbar') %>
 
   <div class="container" style="max-width: 600px; padding-top: 40px;">
-    <div class="card" style="background: #f8f9fa; padding: 20px;">
+    <div class="card" style="background: var(--surface-soft); padding: 20px;">
       <h2 style="margin-bottom: 20px;">🗑️ 注销账号确认</h2>
 
-      <div style="background: #fff3cd; border: 1px solid #ffc107; border-radius: 8px; padding: 16px; margin-bottom: 20px;">
-        <p style="margin: 0; color: #856404; font-size: 0.9rem;">
+      <div style="background: var(--warning-bg); border: 1px solid var(--warning-border); border-radius: 8px; padding: 16px; margin-bottom: 20px;">
+        <p style="margin: 0; color: var(--warning-foreground); font-size: 0.9rem;">
           <strong>⚠️ 注意：</strong>注销后，您的恋爱人格测试结果、匹配记录以及所有个人资料将被永久删除，无法恢复。
         </p>
       </div>
@@ -28,13 +28,13 @@
 
       <form action="/settings/delete" method="POST">
         <div style="margin-bottom: 16px;">
-          <label style="display: block; margin-bottom: 6px; font-size: 0.9rem;">邮箱</label>
-          <input type="email" name="email" placeholder="请输入您的邮箱" style="width: 100%; padding: 10px; border: 1px solid #ddd; border-radius: 8px; box-sizing: border-box;">
+          <label style="display: block; margin-bottom: 6px; font-size: 0.9rem; color: var(--foreground);">邮箱</label>
+          <input type="email" name="email" placeholder="请输入您的邮箱" style="width: 100%; padding: 10px; border: 1px solid var(--input); border-radius: 8px; box-sizing: border-box; background: var(--card); color: var(--foreground);">
         </div>
 
         <div style="margin-bottom: 20px;">
-          <label style="display: block; margin-bottom: 6px; font-size: 0.9rem;">密码</label>
-          <input type="password" name="password" placeholder="请输入您的密码" style="width: 100%; padding: 10px; border: 1px solid #ddd; border-radius: 8px; box-sizing: border-box;">
+          <label style="display: block; margin-bottom: 6px; font-size: 0.9rem; color: var(--foreground);">密码</label>
+          <input type="password" name="password" placeholder="请输入您的密码" style="width: 100%; padding: 10px; border: 1px solid var(--input); border-radius: 8px; box-sizing: border-box; background: var(--card); color: var(--foreground);">
         </div>
 
         <% if (typeof csrfToken !== 'undefined') { %>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -23,7 +23,7 @@
       <p class="subtitle">上大同学之间的互相认识，从这里开始</p>
       <p style="opacity: 0.7; font-size: 0.9rem;">小范围内测中</p>
       <% if (typeof user === 'undefined' || !user) { %>
-        <a href="/login" class="btn btn-large" style="background: white; color: var(--primary); margin-top: 20px;">开始</a>
+        <a href="/login" class="btn btn-large" style="margin-top: 20px;">开始</a>
       <% } %>
     </div>
 

--- a/views/partials/head-icons.ejs
+++ b/views/partials/head-icons.ejs
@@ -6,6 +6,7 @@
   <script>
     (function() {
       var media = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+      var themeColorMeta = document.querySelector('meta[name="theme-color"]');
 
       function getStoredTheme() {
         try {
@@ -22,6 +23,18 @@
         }
       }
 
+      function getEffectiveTheme(theme) {
+        if (theme === 'light' || theme === 'dark') {
+          return theme;
+        }
+        return media && media.matches ? 'dark' : 'light';
+      }
+
+      function syncThemeColor(theme) {
+        if (!themeColorMeta) return;
+        themeColorMeta.setAttribute('content', getEffectiveTheme(theme) === 'dark' ? '#09111f' : '#fafafa');
+      }
+
       function applyTheme(theme) {
         var root = document.documentElement;
         if (theme === 'light' || theme === 'dark') {
@@ -29,6 +42,7 @@
         } else {
           root.removeAttribute('data-theme');
         }
+        syncThemeColor(theme);
       }
 
       function markThemeButtons() {

--- a/views/partials/head-icons.ejs
+++ b/views/partials/head-icons.ejs
@@ -2,7 +2,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png">
   <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
   <link rel="manifest" href="/site.webmanifest">
-  <meta name="theme-color" content="#f06ea8">
+  <meta name="theme-color" content="#fafafa">
   <script>
     (function() {
       var media = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
@@ -33,7 +33,8 @@
 
       function syncThemeColor(theme) {
         if (!themeColorMeta) return;
-        themeColorMeta.setAttribute('content', getEffectiveTheme(theme) === 'dark' ? '#09111f' : '#fafafa');
+        var background = getComputedStyle(document.documentElement).getPropertyValue('--background').trim();
+        themeColorMeta.setAttribute('content', background || (getEffectiveTheme(theme) === 'dark' ? '#09111f' : '#fafafa'));
       }
 
       function getCurrentThemeSelection() {

--- a/views/partials/head-icons.ejs
+++ b/views/partials/head-icons.ejs
@@ -3,3 +3,18 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
   <link rel="manifest" href="/site.webmanifest">
   <meta name="theme-color" content="#f06ea8">
+  <script>
+    (function() {
+      try {
+        var stored = localStorage.getItem('shu-theme');
+        var root = document.documentElement;
+        if (stored === 'light' || stored === 'dark') {
+          root.setAttribute('data-theme', stored);
+        } else {
+          root.removeAttribute('data-theme');
+        }
+      } catch (e) {
+        document.documentElement.removeAttribute('data-theme');
+      }
+    })();
+  </script>

--- a/views/partials/head-icons.ejs
+++ b/views/partials/head-icons.ejs
@@ -9,7 +9,14 @@
 
       function getStoredTheme() {
         try {
-          return localStorage.getItem('shu-theme');
+          var stored = localStorage.getItem('shu-theme');
+          if (stored === 'light' || stored === 'dark') {
+            return stored;
+          }
+          if (stored !== null) {
+            localStorage.removeItem('shu-theme');
+          }
+          return null;
         } catch (e) {
           return null;
         }

--- a/views/partials/head-icons.ejs
+++ b/views/partials/head-icons.ejs
@@ -7,6 +7,7 @@
     (function() {
       var media = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
       var themeColorMeta = document.querySelector('meta[name="theme-color"]');
+      var currentThemeSelection = null;
 
       function getStoredTheme() {
         try {
@@ -35,6 +36,25 @@
         themeColorMeta.setAttribute('content', getEffectiveTheme(theme) === 'dark' ? '#09111f' : '#fafafa');
       }
 
+      function getCurrentThemeSelection() {
+        var storedTheme = getStoredTheme();
+        if (storedTheme) {
+          currentThemeSelection = storedTheme;
+          return storedTheme;
+        }
+
+        if (currentThemeSelection === 'light' || currentThemeSelection === 'dark' || currentThemeSelection === 'system') {
+          return currentThemeSelection;
+        }
+
+        var appliedTheme = document.documentElement.getAttribute('data-theme');
+        if (appliedTheme === 'light' || appliedTheme === 'dark') {
+          return appliedTheme;
+        }
+
+        return 'system';
+      }
+
       function applyTheme(theme) {
         var root = document.documentElement;
         if (theme === 'light' || theme === 'dark') {
@@ -46,7 +66,7 @@
       }
 
       function markThemeButtons() {
-        var current = getStoredTheme() || 'system';
+        var current = getCurrentThemeSelection();
         document.querySelectorAll('[data-theme-option]').forEach(function(button) {
           var isActive = button.getAttribute('data-theme-option') === current;
           button.classList.toggle('is-active', isActive);
@@ -58,6 +78,7 @@
         var button = target.closest('[data-theme-option]');
         if (!button) return false;
         var theme = button.getAttribute('data-theme-option');
+        currentThemeSelection = theme;
         try {
           if (theme === 'system') {
             localStorage.removeItem('shu-theme');
@@ -71,16 +92,18 @@
       }
 
       function handleSystemThemeChange() {
-        if (!getStoredTheme()) {
+        if (getCurrentThemeSelection() === 'system') {
           applyTheme('system');
           markThemeButtons();
         }
       }
 
       try {
-        applyTheme(getStoredTheme() || 'system');
+        currentThemeSelection = getCurrentThemeSelection();
+        applyTheme(currentThemeSelection);
       } catch (e) {
         document.documentElement.removeAttribute('data-theme');
+        currentThemeSelection = 'system';
       }
 
       document.addEventListener('click', function(e) {

--- a/views/partials/head-icons.ejs
+++ b/views/partials/head-icons.ejs
@@ -5,16 +5,81 @@
   <meta name="theme-color" content="#f06ea8">
   <script>
     (function() {
-      try {
-        var stored = localStorage.getItem('shu-theme');
+      var media = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+
+      function getStoredTheme() {
+        try {
+          return localStorage.getItem('shu-theme');
+        } catch (e) {
+          return null;
+        }
+      }
+
+      function applyTheme(theme) {
         var root = document.documentElement;
-        if (stored === 'light' || stored === 'dark') {
-          root.setAttribute('data-theme', stored);
+        if (theme === 'light' || theme === 'dark') {
+          root.setAttribute('data-theme', theme);
         } else {
           root.removeAttribute('data-theme');
         }
+      }
+
+      function markThemeButtons() {
+        var current = getStoredTheme() || 'system';
+        document.querySelectorAll('[data-theme-option]').forEach(function(button) {
+          var isActive = button.getAttribute('data-theme-option') === current;
+          button.classList.toggle('is-active', isActive);
+          button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        });
+      }
+
+      function handleThemeButtonClick(target) {
+        var button = target.closest('[data-theme-option]');
+        if (!button) return false;
+        var theme = button.getAttribute('data-theme-option');
+        try {
+          if (theme === 'system') {
+            localStorage.removeItem('shu-theme');
+          } else {
+            localStorage.setItem('shu-theme', theme);
+          }
+        } catch (err) {}
+        applyTheme(theme);
+        markThemeButtons();
+        return true;
+      }
+
+      function handleSystemThemeChange() {
+        if (!getStoredTheme()) {
+          applyTheme('system');
+          markThemeButtons();
+        }
+      }
+
+      try {
+        applyTheme(getStoredTheme() || 'system');
       } catch (e) {
         document.documentElement.removeAttribute('data-theme');
       }
+
+      document.addEventListener('click', function(e) {
+        handleThemeButtonClick(e.target);
+      });
+
+      document.addEventListener('DOMContentLoaded', function() {
+        markThemeButtons();
+      });
+
+      if (media && typeof media.addEventListener === 'function') {
+        media.addEventListener('change', handleSystemThemeChange);
+      } else if (media && typeof media.addListener === 'function') {
+        media.addListener(handleSystemThemeChange);
+      }
+
+      window.__themeSwitch = {
+        getStoredTheme: getStoredTheme,
+        applyTheme: applyTheme,
+        markThemeButtons: markThemeButtons
+      };
     })();
   </script>

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -19,7 +19,7 @@
       <a href="/notifications" class="notification-link" style="position: relative;">
         通知
         <% if (notificationCount > 0) { %>
-          <span class="notification-badge" style="position: absolute; top: -2px; right: -8px; background: #ef4444; color: white; font-size: 10px; padding: 2px 5px; border-radius: 10px; min-width: 16px; text-align: center;"><%= notificationCount > 99 ? '99+' : notificationCount %></span>
+          <span class="notification-badge" style="position: absolute; top: -2px; right: -8px; background: var(--error); color: white; font-size: 10px; padding: 2px 5px; border-radius: 10px; min-width: 16px; text-align: center;"><%= notificationCount > 99 ? '99+' : notificationCount %></span>
         <% } %>
       </a>
       <div class="theme-switch" role="group" aria-label="主题切换">

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -22,6 +22,11 @@
           <span class="notification-badge" style="position: absolute; top: -2px; right: -8px; background: #ef4444; color: white; font-size: 10px; padding: 2px 5px; border-radius: 10px; min-width: 16px; text-align: center;"><%= notificationCount > 99 ? '99+' : notificationCount %></span>
         <% } %>
       </a>
+      <div class="theme-switch" role="group" aria-label="主题切换">
+        <button type="button" class="theme-switch__button" data-theme-option="system">系统</button>
+        <button type="button" class="theme-switch__button" data-theme-option="light">浅色</button>
+        <button type="button" class="theme-switch__button" data-theme-option="dark">深色</button>
+      </div>
       <% if (typeof user !== 'undefined' && user) { %>
         <!-- 昵称下拉菜单 -->
         <div class="dropdown">
@@ -97,5 +102,68 @@
       closeOpenMenus();
     }
   });
+})();
+
+(function() {
+  if (window.__themeSwitchInitialized) return;
+  window.__themeSwitchInitialized = true;
+  var media = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+
+  function getStoredTheme() {
+    try {
+      return localStorage.getItem('shu-theme');
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function applyTheme(theme) {
+    var root = document.documentElement;
+    if (theme === 'light' || theme === 'dark') {
+      root.setAttribute('data-theme', theme);
+    } else {
+      root.removeAttribute('data-theme');
+    }
+  }
+
+  function markThemeButtons() {
+    var current = getStoredTheme() || 'system';
+    document.querySelectorAll('[data-theme-option]').forEach(function(button) {
+      button.classList.toggle('is-active', button.getAttribute('data-theme-option') === current);
+    });
+  }
+
+  document.addEventListener('click', function(e) {
+    var button = e.target.closest('[data-theme-option]');
+    if (!button) return;
+    var theme = button.getAttribute('data-theme-option');
+    try {
+      if (theme === 'system') {
+        localStorage.removeItem('shu-theme');
+      } else {
+        localStorage.setItem('shu-theme', theme);
+      }
+    } catch (err) {}
+    applyTheme(theme);
+    markThemeButtons();
+  });
+
+  if (media && typeof media.addEventListener === 'function') {
+    media.addEventListener('change', function() {
+      if (!getStoredTheme()) {
+        applyTheme('system');
+        markThemeButtons();
+      }
+    });
+  } else if (media && typeof media.addListener === 'function') {
+    media.addListener(function() {
+      if (!getStoredTheme()) {
+        applyTheme('system');
+        markThemeButtons();
+      }
+    });
+  }
+
+  markThemeButtons();
 })();
 </script>

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -23,9 +23,9 @@
         <% } %>
       </a>
       <div class="theme-switch" role="group" aria-label="主题切换">
-        <button type="button" class="theme-switch__button" data-theme-option="system">系统</button>
-        <button type="button" class="theme-switch__button" data-theme-option="light">浅色</button>
-        <button type="button" class="theme-switch__button" data-theme-option="dark">深色</button>
+        <button type="button" class="theme-switch__button" data-theme-option="system" aria-pressed="false">系统</button>
+        <button type="button" class="theme-switch__button" data-theme-option="light" aria-pressed="false">浅色</button>
+        <button type="button" class="theme-switch__button" data-theme-option="dark" aria-pressed="false">深色</button>
       </div>
       <% if (typeof user !== 'undefined' && user) { %>
         <!-- 昵称下拉菜单 -->
@@ -104,66 +104,4 @@
   });
 })();
 
-(function() {
-  if (window.__themeSwitchInitialized) return;
-  window.__themeSwitchInitialized = true;
-  var media = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
-
-  function getStoredTheme() {
-    try {
-      return localStorage.getItem('shu-theme');
-    } catch (e) {
-      return null;
-    }
-  }
-
-  function applyTheme(theme) {
-    var root = document.documentElement;
-    if (theme === 'light' || theme === 'dark') {
-      root.setAttribute('data-theme', theme);
-    } else {
-      root.removeAttribute('data-theme');
-    }
-  }
-
-  function markThemeButtons() {
-    var current = getStoredTheme() || 'system';
-    document.querySelectorAll('[data-theme-option]').forEach(function(button) {
-      button.classList.toggle('is-active', button.getAttribute('data-theme-option') === current);
-    });
-  }
-
-  document.addEventListener('click', function(e) {
-    var button = e.target.closest('[data-theme-option]');
-    if (!button) return;
-    var theme = button.getAttribute('data-theme-option');
-    try {
-      if (theme === 'system') {
-        localStorage.removeItem('shu-theme');
-      } else {
-        localStorage.setItem('shu-theme', theme);
-      }
-    } catch (err) {}
-    applyTheme(theme);
-    markThemeButtons();
-  });
-
-  if (media && typeof media.addEventListener === 'function') {
-    media.addEventListener('change', function() {
-      if (!getStoredTheme()) {
-        applyTheme('system');
-        markThemeButtons();
-      }
-    });
-  } else if (media && typeof media.addListener === 'function') {
-    media.addListener(function() {
-      if (!getStoredTheme()) {
-        applyTheme('system');
-        markThemeButtons();
-      }
-    });
-  }
-
-  markThemeButtons();
-})();
 </script>

--- a/views/password.ejs
+++ b/views/password.ejs
@@ -11,7 +11,7 @@
   <%- include('partials/navbar') %>
 
   <div class="container" style="max-width: 600px; padding-top: 40px;">
-    <div class="card" style="background: #f8f9fa; padding: 20px;">
+    <div class="card" style="background: var(--surface-soft); padding: 20px;">
       <h2 style="margin-bottom: 20px;">🔐 修改密码</h2>
 
       <% if (typeof passwordMessage !== 'undefined' && passwordMessage) { %>
@@ -22,18 +22,18 @@
 
       <form action="/settings/password" method="POST">
         <div style="margin-bottom: 16px;">
-          <label style="display: block; margin-bottom: 6px; font-size: 0.9rem;">当前密码</label>
-          <input type="password" name="currentPassword" placeholder="若未设置密码则留空" style="width: 100%; padding: 10px; border: 1px solid #ddd; border-radius: 8px; box-sizing: border-box;">
+          <label style="display: block; margin-bottom: 6px; font-size: 0.9rem; color: var(--foreground);">当前密码</label>
+          <input type="password" name="currentPassword" placeholder="若未设置密码则留空" style="width: 100%; padding: 10px; border: 1px solid var(--input); border-radius: 8px; box-sizing: border-box; background: var(--card); color: var(--foreground);">
         </div>
 
         <div style="margin-bottom: 16px;">
-          <label style="display: block; margin-bottom: 6px; font-size: 0.9rem;">新密码</label>
-          <input type="password" name="newPassword" placeholder="至少6位" minlength="6" style="width: 100%; padding: 10px; border: 1px solid #ddd; border-radius: 8px; box-sizing: border-box;">
+          <label style="display: block; margin-bottom: 6px; font-size: 0.9rem; color: var(--foreground);">新密码</label>
+          <input type="password" name="newPassword" placeholder="至少6位" minlength="6" style="width: 100%; padding: 10px; border: 1px solid var(--input); border-radius: 8px; box-sizing: border-box; background: var(--card); color: var(--foreground);">
         </div>
 
         <div style="margin-bottom: 20px;">
-          <label style="display: block; margin-bottom: 6px; font-size: 0.9rem;">确认新密码</label>
-          <input type="password" name="confirmPassword" placeholder="再次输入新密码" style="width: 100%; padding: 10px; border: 1px solid #ddd; border-radius: 8px; box-sizing: border-box;">
+          <label style="display: block; margin-bottom: 6px; font-size: 0.9rem; color: var(--foreground);">确认新密码</label>
+          <input type="password" name="confirmPassword" placeholder="再次输入新密码" style="width: 100%; padding: 10px; border: 1px solid var(--input); border-radius: 8px; box-sizing: border-box; background: var(--card); color: var(--foreground);">
         </div>
 
         <button type="submit" class="btn btn-secondary">修改密码</button>

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -396,8 +396,9 @@
       padding: 8px 16px;
       border-radius: 20px;
       background: var(--profile-surface-soft);
-      color: var(--profile-text-muted);
+      color: var(--foreground);
       font-size: 13px;
+      font-weight: 500;
       transition: all 0.3s;
     }
     .pagination-step.active {
@@ -413,11 +414,58 @@
       height: 22px;
       border-radius: 50%;
       background: var(--profile-step-badge-bg);
+      border: 1px solid var(--profile-border);
+      color: var(--foreground);
       display: flex;
       align-items: center;
       justify-content: center;
       font-size: 12px;
       font-weight: 600;
+    }
+    .pagination-step.active .pagination-step-number {
+      background: rgba(255, 255, 255, 0.18);
+      border-color: transparent;
+      color: #fff;
+    }
+    .pagination-step.completed .pagination-step-number {
+      background: rgba(255, 255, 255, 0.82);
+      border-color: rgba(232, 90, 90, 0.18);
+      color: var(--primary);
+    }
+    html[data-theme="dark"] body.profile-page {
+      --profile-step-completed: rgba(232, 90, 90, 0.10);
+      --profile-step-badge-bg: rgba(255, 255, 255, 0.07);
+    }
+    html[data-theme="dark"] .pagination-step {
+      background: rgba(255, 255, 255, 0.035);
+      border: 1px solid rgba(255, 255, 255, 0.07);
+      color: rgba(255, 255, 255, 0.7);
+    }
+    html[data-theme="dark"] .pagination-step.active {
+      background: rgba(232, 90, 90, 0.24);
+      border-color: rgba(232, 90, 90, 0.28);
+      box-shadow: inset 0 0 0 1px rgba(232, 90, 90, 0.18);
+      color: #fff;
+    }
+    html[data-theme="dark"] .pagination-step.completed {
+      background: rgba(232, 90, 90, 0.10);
+      border-color: rgba(232, 90, 90, 0.16);
+      color: #ffc0b6;
+    }
+    html[data-theme="dark"] .pagination-step-number {
+      background: rgba(255, 255, 255, 0.06);
+      border-color: rgba(255, 255, 255, 0.08);
+      color: rgba(255, 255, 255, 0.86);
+    }
+    html[data-theme="dark"] .pagination-step.active .pagination-step-number {
+      background: rgba(255, 255, 255, 0.16);
+      border-color: rgba(255, 255, 255, 0.12);
+      color: #fff;
+    }
+    html[data-theme="dark"] .pagination-step.completed .pagination-step-number {
+      background: rgba(232, 90, 90, 0.14);
+      border-color: rgba(232, 90, 90, 0.2);
+      color: #ffe3de;
     }
     .pagination-buttons {
       display: flex;

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -656,7 +656,7 @@
       <div class="form-group">
         <label>(b). 我希望匹配到的对象年龄范围：</label>
         <div class="range-container">
-          <input type="range" class="range-slider" name="age_min" id="ageMin" min="16" max="30" value="<%= profile && profile.age_min ? profile.age_min : 18 %>" oninput="updateAgeRangeDisplay()">
+          <input type="range" class="range-slider" name="age_min" id="ageMin" min="16" max="30" value="<%= profile && profile.age_min ? profile.age_min : 18 %>" oninput="updateAgeRangeDisplay(this)">
           <div class="range-labels">
             <span>16岁</span>
             <span>23岁</span>
@@ -664,7 +664,7 @@
           </div>
           <div class="range-value" id="ageMinValue">最小 <%= profile && profile.age_min ? profile.age_min : 18 %> 岁</div>
 
-          <input type="range" class="range-slider" name="age_max" id="ageMax" min="16" max="30" value="<%= profile && profile.age_max ? profile.age_max : 28 %>" oninput="updateAgeRangeDisplay()">
+          <input type="range" class="range-slider" name="age_max" id="ageMax" min="16" max="30" value="<%= profile && profile.age_max ? profile.age_max : 28 %>" oninput="updateAgeRangeDisplay(this)">
           <div class="range-labels">
             <span>16岁</span>
             <span>23岁</span>
@@ -748,7 +748,7 @@
       <div class="form-group">
         <label>(b). 我对匹配对象的身高偏好（cm）：</label>
         <div class="range-container">
-          <input type="range" class="range-slider" name="preferred_height_min" id="preferredHeightMin" min="140" max="210" value="<%= profile && profile.preferred_height_min ? profile.preferred_height_min : 160 %>" oninput="updatePreferredHeightDisplay()">
+          <input type="range" class="range-slider" name="preferred_height_min" id="preferredHeightMin" min="140" max="210" value="<%= profile && profile.preferred_height_min ? profile.preferred_height_min : 160 %>" oninput="updatePreferredHeightDisplay(this)">
           <div class="range-labels">
             <span>140cm</span>
             <span>175cm</span>
@@ -756,7 +756,7 @@
           </div>
           <div class="range-value" id="preferredHeightMinValue">最低 <%= profile && profile.preferred_height_min ? profile.preferred_height_min : 160 %> cm</div>
 
-          <input type="range" class="range-slider" name="preferred_height_max" id="preferredHeightMax" min="140" max="210" value="<%= profile && profile.preferred_height_max ? profile.preferred_height_max : 180 %>" oninput="updatePreferredHeightDisplay()">
+          <input type="range" class="range-slider" name="preferred_height_max" id="preferredHeightMax" min="140" max="210" value="<%= profile && profile.preferred_height_max ? profile.preferred_height_max : 180 %>" oninput="updatePreferredHeightDisplay(this)">
           <div class="range-labels">
             <span>140cm</span>
             <span>175cm</span>
@@ -1732,11 +1732,20 @@ function updateMyAgeDisplay() {
   document.getElementById('myAgeValue').textContent = s.value + ' 岁';
 }
 
-function updateAgeRangeDisplay() {
+function updateAgeRangeDisplay(changedSlider) {
   const minS = document.getElementById('ageMin');
   const maxS = document.getElementById('ageMax');
   let minVal = +minS.value, maxVal = +maxS.value;
-  if (minVal > maxVal) { minS.value = maxVal; minVal = maxVal; }
+  const activeSlider = changedSlider || document.activeElement;
+  if (minVal > maxVal) {
+    if (activeSlider === maxS) {
+      minS.value = maxVal;
+      minVal = maxVal;
+    } else {
+      maxS.value = minVal;
+      maxVal = minVal;
+    }
+  }
   setSliderBg(minS, calcPercent(minVal, 16, 30));
   setSliderBg(maxS, calcPercent(maxVal, 16, 30));
   document.getElementById('ageMinValue').textContent = '最小 ' + minVal + ' 岁';
@@ -1749,21 +1758,28 @@ function updateMyHeightDisplay() {
   document.getElementById('myHeightValue').textContent = s.value + ' cm';
 }
 
-function updatePreferredHeightDisplay() {
+function updatePreferredHeightDisplay(changedSlider) {
   const minSlider = document.getElementById('preferredHeightMin');
   const maxSlider = document.getElementById('preferredHeightMax');
-  const minVal = parseInt(minSlider.value);
-  const maxVal = parseInt(maxSlider.value);
+  let minVal = parseInt(minSlider.value);
+  let maxVal = parseInt(maxSlider.value);
+  const activeSlider = changedSlider || document.activeElement;
 
   if (minVal > maxVal) {
-    minSlider.value = maxVal;
+    if (activeSlider === maxSlider) {
+      minSlider.value = maxVal;
+      minVal = maxVal;
+    } else {
+      maxSlider.value = minVal;
+      maxVal = minVal;
+    }
   }
 
-  setSliderBg(minSlider, calcPercent(minSlider.value, 140, 210));
-  setSliderBg(maxSlider, calcPercent(maxSlider.value, 140, 210));
+  setSliderBg(minSlider, calcPercent(minVal, 140, 210));
+  setSliderBg(maxSlider, calcPercent(maxVal, 140, 210));
 
-  document.getElementById('preferredHeightMinValue').textContent = '最低 ' + minSlider.value + ' cm';
-  document.getElementById('preferredHeightMaxValue').textContent = '最高 ' + maxSlider.value + ' cm';
+  document.getElementById('preferredHeightMinValue').textContent = '最低 ' + minVal + ' cm';
+  document.getElementById('preferredHeightMaxValue').textContent = '最高 ' + maxVal + ' cm';
 }
 
 function updateTagCounter(name, counterId, max = 5) {

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -18,17 +18,17 @@
       --profile-input: var(--input);
       --profile-text-muted: var(--muted-foreground);
       --profile-text-subtle: var(--muted-foreground);
-      --profile-step-completed: rgba(232, 90, 90, 0.18);
-      --profile-step-badge-bg: rgba(255, 255, 255, 0.3);
+      --profile-step-completed: var(--primary-light);
+      --profile-step-badge-bg: var(--surface-elevated);
       --profile-slider-track: var(--border);
       --profile-slider-thumb: var(--card);
-      --profile-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+      --profile-shadow: var(--shadow-sm);
       --profile-love-bg: linear-gradient(135deg, var(--accent) 0%, var(--card) 100%);
-      --profile-love-border: rgba(232, 90, 90, 0.2);
+      --profile-love-border: var(--border);
       --profile-love-chip-bg: var(--card);
-      --profile-love-chip-border: rgba(232, 90, 90, 0.16);
+      --profile-love-chip-border: var(--border);
       --profile-love-question-bg: var(--primary-light);
-      --profile-love-question-border: rgba(232, 90, 90, 0.18);
+      --profile-love-question-border: var(--border);
     }
 
     .option-group {
@@ -1711,11 +1711,19 @@ function calcPercent(val, min, max) {
   return (val - min) / (max - min) * 100;
 }
 
-function setSliderBg(slider, percent) {
+const sliderTheme = {
+  active: '#3b82f6',
+  track: '#d1d5db'
+};
+
+function refreshSliderTheme() {
   const styles = getComputedStyle(document.body);
-  const active = styles.getPropertyValue('--info').trim() || '#3b82f6';
-  const track = styles.getPropertyValue('--input').trim() || '#d1d5db';
-  slider.style.background = `linear-gradient(to right, ${active} 0%, ${active} ${percent}%, ${track} ${percent}%, ${track} 100%)`;
+  sliderTheme.active = styles.getPropertyValue('--info').trim() || '#3b82f6';
+  sliderTheme.track = styles.getPropertyValue('--input').trim() || '#d1d5db';
+}
+
+function setSliderBg(slider, percent) {
+  slider.style.background = `linear-gradient(to right, ${sliderTheme.active} 0%, ${sliderTheme.active} ${percent}%, ${sliderTheme.track} ${percent}%, ${sliderTheme.track} 100%)`;
 }
 
 function updateMyAgeDisplay() {
@@ -1799,6 +1807,7 @@ document.addEventListener('DOMContentLoaded', function() {
   const surveyForm = document.querySelector('form[action="/survey/submit"]');
   if (!surveyForm) return;
 
+  refreshSliderTheme();
   updateMyAgeDisplay();
   updateAgeRangeDisplay();
   updateMyHeightDisplay();
@@ -1908,6 +1917,40 @@ document.addEventListener('DOMContentLoaded', function() {
   const totalSteps = Math.min(steps.length, sections.length);
   let currentStep = 1;
   const hasPaginationControls = Boolean(prevBtn && nextBtn && submitBtn && totalSteps > 0);
+
+  document.addEventListener('click', function(e) {
+    if (!e.target.closest('[data-theme-option]')) return;
+    requestAnimationFrame(function() {
+      refreshSliderTheme();
+      updateMyAgeDisplay();
+      updateAgeRangeDisplay();
+      updateMyHeightDisplay();
+      updatePreferredHeightDisplay();
+    });
+  });
+
+  const themeMedia = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+  if (themeMedia && typeof themeMedia.addEventListener === 'function') {
+    themeMedia.addEventListener('change', function() {
+      if (!localStorage.getItem('shu-theme')) {
+        refreshSliderTheme();
+        updateMyAgeDisplay();
+        updateAgeRangeDisplay();
+        updateMyHeightDisplay();
+        updatePreferredHeightDisplay();
+      }
+    });
+  } else if (themeMedia && typeof themeMedia.addListener === 'function') {
+    themeMedia.addListener(function() {
+      if (!localStorage.getItem('shu-theme')) {
+        refreshSliderTheme();
+        updateMyAgeDisplay();
+        updateAgeRangeDisplay();
+        updateMyHeightDisplay();
+        updatePreferredHeightDisplay();
+      }
+    });
+  }
 
   function updatePagination() {
     if (!hasPaginationControls) return;

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -29,6 +29,23 @@
       --profile-love-chip-border: var(--border);
       --profile-love-question-bg: var(--primary-light);
       --profile-love-question-border: var(--border);
+      --profile-step-bg: var(--profile-surface-soft);
+      --profile-step-text: var(--profile-text-muted);
+      --profile-step-border: var(--profile-border);
+      --profile-step-active-bg: var(--primary);
+      --profile-step-active-text: #fff;
+      --profile-step-active-border: var(--primary);
+      --profile-step-active-badge-bg: var(--profile-surface);
+      --profile-step-active-badge-text: var(--primary);
+      --profile-step-active-badge-border: var(--profile-surface);
+      --profile-step-completed-bg: var(--profile-step-completed);
+      --profile-step-completed-text: var(--primary);
+      --profile-step-completed-border: var(--profile-step-completed);
+      --profile-step-completed-badge-bg: var(--profile-surface);
+      --profile-step-completed-badge-text: var(--primary);
+      --profile-step-completed-badge-border: var(--profile-step-completed);
+      --profile-step-badge-text: var(--foreground);
+      --profile-step-badge-border: var(--profile-border);
     }
 
     .option-group {
@@ -395,27 +412,30 @@
       gap: 6px;
       padding: 8px 16px;
       border-radius: 20px;
-      background: var(--profile-surface-soft);
-      color: var(--foreground);
+      background: var(--profile-step-bg);
+      color: var(--profile-step-text);
+      border: 1px solid var(--profile-step-border);
       font-size: 13px;
       font-weight: 500;
       transition: all 0.3s;
     }
     .pagination-step.active {
-      background: var(--primary);
-      color: #fff;
+      background: var(--profile-step-active-bg);
+      color: var(--profile-step-active-text);
+      border-color: var(--profile-step-active-border);
     }
     .pagination-step.completed {
-      background: var(--profile-step-completed);
-      color: var(--primary);
+      background: var(--profile-step-completed-bg);
+      color: var(--profile-step-completed-text);
+      border-color: var(--profile-step-completed-border);
     }
     .pagination-step-number {
       width: 22px;
       height: 22px;
       border-radius: 50%;
       background: var(--profile-step-badge-bg);
-      border: 1px solid var(--profile-border);
-      color: var(--foreground);
+      border: 1px solid var(--profile-step-badge-border);
+      color: var(--profile-step-badge-text);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -423,49 +443,14 @@
       font-weight: 600;
     }
     .pagination-step.active .pagination-step-number {
-      background: rgba(255, 255, 255, 0.18);
-      border-color: transparent;
-      color: #fff;
+      background: var(--profile-step-active-badge-bg);
+      border-color: var(--profile-step-active-badge-border);
+      color: var(--profile-step-active-badge-text);
     }
     .pagination-step.completed .pagination-step-number {
-      background: rgba(255, 255, 255, 0.82);
-      border-color: rgba(232, 90, 90, 0.18);
-      color: var(--primary);
-    }
-    html[data-theme="dark"] body.profile-page {
-      --profile-step-completed: rgba(232, 90, 90, 0.10);
-      --profile-step-badge-bg: rgba(255, 255, 255, 0.07);
-    }
-    html[data-theme="dark"] .pagination-step {
-      background: rgba(255, 255, 255, 0.035);
-      border: 1px solid rgba(255, 255, 255, 0.07);
-      color: rgba(255, 255, 255, 0.7);
-    }
-    html[data-theme="dark"] .pagination-step.active {
-      background: rgba(232, 90, 90, 0.24);
-      border-color: rgba(232, 90, 90, 0.28);
-      box-shadow: inset 0 0 0 1px rgba(232, 90, 90, 0.18);
-      color: #fff;
-    }
-    html[data-theme="dark"] .pagination-step.completed {
-      background: rgba(232, 90, 90, 0.10);
-      border-color: rgba(232, 90, 90, 0.16);
-      color: #ffc0b6;
-    }
-    html[data-theme="dark"] .pagination-step-number {
-      background: rgba(255, 255, 255, 0.06);
-      border-color: rgba(255, 255, 255, 0.08);
-      color: rgba(255, 255, 255, 0.86);
-    }
-    html[data-theme="dark"] .pagination-step.active .pagination-step-number {
-      background: rgba(255, 255, 255, 0.16);
-      border-color: rgba(255, 255, 255, 0.12);
-      color: #fff;
-    }
-    html[data-theme="dark"] .pagination-step.completed .pagination-step-number {
-      background: rgba(232, 90, 90, 0.14);
-      border-color: rgba(232, 90, 90, 0.2);
-      color: #ffe3de;
+      background: var(--profile-step-completed-badge-bg);
+      border-color: var(--profile-step-completed-badge-border);
+      color: var(--profile-step-completed-badge-text);
     }
     .pagination-buttons {
       display: flex;
@@ -1767,7 +1752,10 @@ const sliderTheme = {
 function refreshSliderTheme() {
   const styles = getComputedStyle(document.body);
   sliderTheme.active = styles.getPropertyValue('--info').trim() || '#3b82f6';
-  sliderTheme.track = styles.getPropertyValue('--input').trim() || '#d1d5db';
+  sliderTheme.track =
+    styles.getPropertyValue('--profile-slider-track').trim() ||
+    styles.getPropertyValue('--input').trim() ||
+    '#d1d5db';
 }
 
 function setSliderBg(slider, percent) {

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -1930,9 +1930,19 @@ document.addEventListener('DOMContentLoaded', function() {
   });
 
   const themeMedia = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+  function getStoredThemeSafe() {
+    if (window.__themeSwitch && typeof window.__themeSwitch.getStoredTheme === 'function') {
+      return window.__themeSwitch.getStoredTheme();
+    }
+    try {
+      return localStorage.getItem('shu-theme');
+    } catch (e) {
+      return null;
+    }
+  }
   if (themeMedia && typeof themeMedia.addEventListener === 'function') {
     themeMedia.addEventListener('change', function() {
-      if (!localStorage.getItem('shu-theme')) {
+      if (!getStoredThemeSafe()) {
         refreshSliderTheme();
         updateMyAgeDisplay();
         updateAgeRangeDisplay();
@@ -1942,7 +1952,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   } else if (themeMedia && typeof themeMedia.addListener === 'function') {
     themeMedia.addListener(function() {
-      if (!localStorage.getItem('shu-theme')) {
+      if (!getStoredThemeSafe()) {
         refreshSliderTheme();
         updateMyAgeDisplay();
         updateAgeRangeDisplay();

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -650,7 +650,7 @@
 
     <!-- 一、基础信息 -->
     <div class="form-section form-section-pagination active" data-step="1">
-      <h3 style="color: #e74c3c; margin: 20px 0 15px;">一、基础信息</h3>
+      <h3 style="color: var(--primary); margin: 20px 0 15px;">一、基础信息</h3>
 
       <div class="form-group">
         <label>1(a). 我的性别是：</label>
@@ -881,7 +881,7 @@
 
     <!-- 二、恋爱观念 -->
     <div class="form-section form-section-pagination" data-step="2">
-      <h3 style="color: #e74c3c; margin: 20px 0 15px;">二、恋爱观念</h3>
+      <h3 style="color: var(--primary); margin: 20px 0 15px;">二、恋爱观念</h3>
 
       <div class="form-group">
         <label>9. 恋爱里我更倾向的相处节奏：</label>
@@ -1367,7 +1367,7 @@
 
     <!-- 三、个人特征与匹配偏好 -->
     <div class="form-section form-section-pagination" data-step="3">
-      <h3 style="color: #e74c3c; margin: 20px 0 15px;">三、个人特征与匹配偏好</h3>
+      <h3 style="color: var(--primary); margin: 20px 0 15px;">三、个人特征与匹配偏好</h3>
 
       <div class="form-group">
         <label>23(a). 整体而言，我本人展现出的自身特质通常被认为是（最多选5项）：</label>
@@ -1550,7 +1550,7 @@
 
 <!-- 四、Love Type16 恋爱类型测试 -->
 <div class="form-section form-section-pagination" data-step="4">
-  <h3 style="color: #e74c3c; margin: 20px 0 15px;"> 四、Love Type16 恋爱类型测试 </h3>
+  <h3 style="color: var(--primary); margin: 20px 0 15px;"> 四、Love Type16 恋爱类型测试 </h3>
   <% lovetypeQuestions.forEach(function(question) { %>
     <div class="form-group">
       <label>

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -10,6 +10,27 @@
   <link rel="stylesheet" href="/css/dev-tools.css">
   <% } %>
   <style>
+    body.profile-page {
+      --profile-surface: var(--card);
+      --profile-surface-soft: var(--surface-soft);
+      --profile-surface-tint: var(--primary-light);
+      --profile-border: var(--border);
+      --profile-input: var(--input);
+      --profile-text-muted: var(--muted-foreground);
+      --profile-text-subtle: var(--muted-foreground);
+      --profile-step-completed: rgba(232, 90, 90, 0.18);
+      --profile-step-badge-bg: rgba(255, 255, 255, 0.3);
+      --profile-slider-track: var(--border);
+      --profile-slider-thumb: var(--card);
+      --profile-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+      --profile-love-bg: linear-gradient(135deg, var(--accent) 0%, var(--card) 100%);
+      --profile-love-border: rgba(232, 90, 90, 0.2);
+      --profile-love-chip-bg: var(--card);
+      --profile-love-chip-border: rgba(232, 90, 90, 0.16);
+      --profile-love-question-bg: var(--primary-light);
+      --profile-love-question-border: rgba(232, 90, 90, 0.18);
+    }
+
     .option-group {
       display: flex;
       flex-wrap: wrap;
@@ -21,18 +42,18 @@
       gap: 6px;
       padding: 10px 14px;
       border-radius: 8px;
-      border: 1px solid #e0e0e0;
-      background: #fff;
+      border: 1px solid var(--profile-border);
+      background: var(--profile-surface);
       cursor: pointer;
       transition: all 0.2s;
     }
     .option-group label:hover {
-      border-color: #e74c3c;
-      background: #fff8f6;
+      border-color: var(--primary);
+      background: var(--profile-surface-tint);
     }
     .option-group label.selected {
-      border-color: #e74c3c;
-      background: #fff0ed;
+      border-color: var(--primary);
+      background: var(--profile-surface-tint);
     }
     .option-group input[type="radio"] {
       width: auto;
@@ -51,12 +72,12 @@
       display: flex;
       justify-content: space-between;
       font-size: 12px;
-      color: #666;
+      color: var(--profile-text-muted);
     }
     .range-value {
       text-align: center;
       font-weight: 600;
-      color: #e74c3c;
+      color: var(--primary);
       margin-top: 8px;
     }
 
@@ -72,18 +93,18 @@
       gap: 6px;
       padding: 10px 12px;
       border-radius: 8px;
-      border: 1px solid #e0e0e0;
-      background: #fff;
+      border: 1px solid var(--profile-border);
+      background: var(--profile-surface);
       cursor: pointer;
       transition: all 0.2s;
     }
     .checkbox-group-grid label:hover {
-      border-color: #e74c3c;
-      background: #fff8f6;
+      border-color: var(--primary);
+      background: var(--profile-surface-tint);
     }
     .checkbox-group-grid label.checked {
-      border-color: #e74c3c;
-      background: #fff0ed;
+      border-color: var(--primary);
+      background: var(--profile-surface-tint);
     }
     .checkbox-group-grid input[type="checkbox"] {
       width: auto;
@@ -95,8 +116,10 @@
       width: 100%;
       padding: 10px;
       border-radius: 8px;
-      border: 1px solid #e0e0e0;
+      border: 1px solid var(--profile-input);
       font-size: 14px;
+      background: var(--profile-surface);
+      color: var(--foreground);
     }
 
     /* 5-point scale for new questions */
@@ -111,20 +134,20 @@
       align-items: center;
       padding: 12px 8px;
       border-radius: 10px;
-      border: 1px solid #e0e0e0;
-      background: #fff;
+      border: 1px solid var(--profile-border);
+      background: var(--profile-surface);
       cursor: pointer;
       text-align: center;
       font-size: 13px;
       transition: all 0.2s;
     }
     .scale-5 label:hover {
-      border-color: #e74c3c;
-      background: #fff8f6;
+      border-color: var(--primary);
+      background: var(--profile-surface-tint);
     }
     .scale-5 label.selected {
-      border-color: #e74c3c;
-      background: #fff0ed;
+      border-color: var(--primary);
+      background: var(--profile-surface-tint);
     }
     .scale-5 input[type="radio"] {
       width: auto;
@@ -134,7 +157,7 @@
       display: flex;
       justify-content: space-between;
       font-size: 12px;
-      color: #888;
+      color: var(--profile-text-subtle);
       margin-bottom: 8px;
     }
 
@@ -144,7 +167,7 @@
     }
     .interest-category-title {
       font-weight: 600;
-      color: #e74c3c;
+      color: var(--primary);
       margin-bottom: 10px;
       font-size: 14px;
     }
@@ -159,29 +182,29 @@
       gap: 6px;
       padding: 8px 12px;
       border-radius: 20px;
-      border: 1px solid #e0e0e0;
-      background: #fff;
+      border: 1px solid var(--profile-border);
+      background: var(--profile-surface);
       cursor: pointer;
       transition: all 0.2s;
     }
     .interest-tag:hover {
-      border-color: #e74c3c;
+      border-color: var(--primary);
     }
     .interest-tag.selected {
-      border-color: #e74c3c;
-      background: #fff0ed;
+      border-color: var(--primary);
+      background: var(--profile-surface-tint);
     }
     .interest-tag input {
       display: none;
     }
     .interest-counter {
       font-size: 13px;
-      color: #666;
+      color: var(--profile-text-muted);
       margin-bottom: 12px;
     }
 
     .form-section {
-      border-bottom: 1px solid #eee;
+      border-bottom: 1px solid var(--profile-border);
       padding-bottom: 10px;
       margin-bottom: 10px;
     }
@@ -191,17 +214,17 @@
       margin-bottom: 8px;
       cursor: pointer;
       padding: 6px 12px;
-      border: 1px solid #ddd;
+      border: 1px solid var(--profile-border);
       border-radius: 6px;
       transition: all 0.2s;
     }
     .checkbox-group label:hover {
-      border-color: #e74c3c;
-      background: #fff8f6;
+      border-color: var(--primary);
+      background: var(--profile-surface-tint);
     }
     .checkbox-group label.checked {
-      border-color: #e74c3c;
-      background: #fff0ed;
+      border-color: var(--primary);
+      background: var(--profile-surface-tint);
     }
     .checkbox-group input[type="checkbox"] {
       width: auto;
@@ -218,7 +241,7 @@
     }
     .scale-label-text {
       font-size: 12px;
-      color: #888;
+      color: var(--profile-text-subtle);
       width: 200px;
       flex-shrink: 0;
       word-wrap: break-word;
@@ -258,23 +281,23 @@
       width: 36px;
       height: 36px;
       border-radius: 50%;
-      border: 2px solid #e0e0e0;
-      background: #fff;
+      border: 2px solid var(--profile-border);
+      background: var(--profile-surface);
       display: flex;
       align-items: center;
       justify-content: center;
       font-size: 12px;
       font-weight: 600;
-      color: #666;
+      color: var(--profile-text-muted);
       transition: all 0.2s;
     }
     .scale-option:hover .scale-circle {
-      border-color: #e74c3c;
-      color: #e74c3c;
+      border-color: var(--primary);
+      color: var(--primary);
     }
     .scale-option.selected .scale-circle {
-      border-color: #e74c3c;
-      background: #e74c3c;
+      border-color: var(--primary);
+      background: var(--primary);
       color: #fff;
     }
     .scale-option input[type="radio"] {
@@ -295,7 +318,7 @@
       left: 0;
       right: 0;
       height: 6px;
-      background: #e0e0e0;
+      background: var(--profile-slider-track);
       border-radius: 3px;
       transform: translateY(-50%);
     }
@@ -303,7 +326,7 @@
       position: absolute;
       top: 50%;
       height: 6px;
-      background: #e74c3c;
+      background: var(--primary);
       border-radius: 3px;
       transform: translateY(-50%);
     }
@@ -324,33 +347,33 @@
       width: 22px;
       height: 22px;
       border-radius: 50%;
-      background: #fff;
-      border: 3px solid #e74c3c;
+      background: var(--profile-slider-thumb);
+      border: 3px solid var(--primary);
       cursor: pointer;
       pointer-events: auto;
-      box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+      box-shadow: var(--profile-shadow);
     }
     .dual-range-input::-moz-range-thumb {
       width: 22px;
       height: 22px;
       border-radius: 50%;
-      background: #fff;
-      border: 3px solid #e74c3c;
+      background: var(--profile-slider-thumb);
+      border: 3px solid var(--primary);
       cursor: pointer;
       pointer-events: auto;
-      box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+      box-shadow: var(--profile-shadow);
     }
     .dual-range-labels {
       display: flex;
       justify-content: space-between;
       margin-top: 8px;
       font-size: 12px;
-      color: #888;
+      color: var(--profile-text-subtle);
     }
     .dual-range-value {
       text-align: center;
       font-weight: 600;
-      color: #e74c3c;
+      color: var(--primary);
       margin-top: 12px;
       font-size: 15px;
     }
@@ -372,24 +395,24 @@
       gap: 6px;
       padding: 8px 16px;
       border-radius: 20px;
-      background: #f0f0f0;
-      color: #666;
+      background: var(--profile-surface-soft);
+      color: var(--profile-text-muted);
       font-size: 13px;
       transition: all 0.3s;
     }
     .pagination-step.active {
-      background: #e74c3c;
+      background: var(--primary);
       color: #fff;
     }
     .pagination-step.completed {
-      background: #fadbd8;
-      color: #e74c3c;
+      background: var(--profile-step-completed);
+      color: var(--primary);
     }
     .pagination-step-number {
       width: 22px;
       height: 22px;
       border-radius: 50%;
-      background: rgba(255,255,255,0.3);
+      background: var(--profile-step-badge-bg);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -409,7 +432,7 @@
       display: block;
     }
     .form-group--error {
-      border: 2px solid #e74c3c;
+      border: 2px solid var(--primary);
       border-radius: 10px;
       padding: 12px 14px;
       margin-left: -14px;
@@ -417,12 +440,12 @@
     }
   </style>
 </head>
-<body>
+<body class="profile-page">
   <%- include('partials/navbar') %>
 
   <div class="container" style="max-width: 800px;">
     <% if (typeof showPassword !== 'undefined' && showPassword) { %>
-    <div class="card" style="background: #f8f9fa; padding: 20px; margin-bottom: 20px;">
+    <div class="card" style="background: var(--surface-soft); padding: 20px; margin-bottom: 20px;">
       <h3 style="margin-bottom: 16px;">🔐 修改密码</h3>
 
       <% if (typeof passwordMessage !== 'undefined' && passwordMessage) { %>
@@ -433,17 +456,17 @@
 
       <form action="/profile/password" method="POST" style="display: grid; grid-template-columns: 1fr 1fr; gap: 12px;">
         <div>
-          <label style="display: block; margin-bottom: 6px; font-size: 0.9rem;">当前密码</label>
-          <input type="password" name="currentPassword" placeholder="若未设置密码则留空" style="width: 100%; padding: 10px; border: 1px solid #ddd; border-radius: 8px;">
+          <label style="display: block; margin-bottom: 6px; font-size: 0.9rem; color: var(--foreground);">当前密码</label>
+          <input type="password" name="currentPassword" placeholder="若未设置密码则留空" style="width: 100%; padding: 10px; border: 1px solid var(--input); border-radius: 8px; background: var(--card); color: var(--foreground);">
         </div>
         <div></div>
         <div>
-          <label style="display: block; margin-bottom: 6px; font-size: 0.9rem;">新密码</label>
-          <input type="password" name="newPassword" placeholder="至少6位" minlength="6" style="width: 100%; padding: 10px; border: 1px solid #ddd; border-radius: 8px;">
+          <label style="display: block; margin-bottom: 6px; font-size: 0.9rem; color: var(--foreground);">新密码</label>
+          <input type="password" name="newPassword" placeholder="至少6位" minlength="6" style="width: 100%; padding: 10px; border: 1px solid var(--input); border-radius: 8px; background: var(--card); color: var(--foreground);">
         </div>
         <div>
-          <label style="display: block; margin-bottom: 6px; font-size: 0.9rem;">确认新密码</label>
-          <input type="password" name="confirmPassword" placeholder="再次输入新密码" style="width: 100%; padding: 10px; border: 1px solid #ddd; border-radius: 8px;">
+          <label style="display: block; margin-bottom: 6px; font-size: 0.9rem; color: var(--foreground);">确认新密码</label>
+          <input type="password" name="confirmPassword" placeholder="再次输入新密码" style="width: 100%; padding: 10px; border: 1px solid var(--input); border-radius: 8px; background: var(--card); color: var(--foreground);">
         </div>
         <div style="grid-column: 1 / -1;">
           <button type="submit" class="btn btn-secondary">修改密码</button>
@@ -1532,15 +1555,15 @@
 
 <style>
 .lovetype-intro {
-  color: #666;
+  color: var(--profile-text-muted);
   margin-bottom: 16px;
 }
 .lovetype-question {
   padding: 16px;
   margin-bottom: 16px;
-  border: 1px solid #f0d5d0;
+  border: 1px solid var(--profile-love-question-border);
   border-radius: 12px;
-  background: #fff8f6;
+  background: var(--profile-love-question-bg);
 }
 .lovetype-question-head {
   margin-bottom: 12px;
@@ -1550,15 +1573,15 @@
   justify-content: space-between;
   gap: 12px;
   margin-top: 8px;
-  color: #666;
+  color: var(--profile-text-muted);
   font-size: 13px;
 }
 .lovetype-result-card {
   margin-bottom: 24px;
   padding: 20px;
   border-radius: 14px;
-  background: linear-gradient(135deg, #fff4ef 0%, #fff 100%);
-  border: 1px solid #f3d2c8;
+  background: var(--profile-love-bg);
+  border: 1px solid var(--profile-love-border);
 }
 .lovetype-result-header {
   display: flex;
@@ -1571,7 +1594,7 @@
 }
 .lovetype-result-header p {
   margin: 0;
-  color: #666;
+  color: var(--profile-text-muted);
 }
 .lovetype-badge {
   display: inline-flex;
@@ -1581,7 +1604,7 @@
   height: 42px;
   padding: 0 14px;
   border-radius: 999px;
-  background: #e74c3c;
+  background: var(--primary);
   color: #fff;
   font-weight: 700;
   letter-spacing: 1px;
@@ -1597,8 +1620,8 @@
   gap: 8px;
   padding: 8px 12px;
   border-radius: 999px;
-  background: #fff;
-  border: 1px solid #f1d5cf;
+  background: var(--profile-love-chip-bg);
+  border: 1px solid var(--profile-love-chip-border);
 }
 .lovetype-copy-block {
   margin-top: 18px;
@@ -1609,7 +1632,7 @@
 }
 .lovetype-copy-block p {
   margin-bottom: 8px;
-  color: #444;
+  color: var(--foreground);
 }
 .lovetype-type-list {
   display: flex;
@@ -1622,8 +1645,8 @@
   align-items: center;
   padding: 6px 12px;
   border-radius: 999px;
-  background: #fff;
-  border: 1px solid #f1d5cf;
+  background: var(--profile-love-chip-bg);
+  border: 1px solid var(--profile-love-chip-border);
   font-size: 13px;
   font-weight: 600;
 }
@@ -1689,7 +1712,10 @@ function calcPercent(val, min, max) {
 }
 
 function setSliderBg(slider, percent) {
-  slider.style.background = `linear-gradient(to right, #3b82f6 0%, #3b82f6 ${percent}%, #d1d5db ${percent}%, #d1d5db 100%)`;
+  const styles = getComputedStyle(document.body);
+  const active = styles.getPropertyValue('--info').trim() || '#3b82f6';
+  const track = styles.getPropertyValue('--input').trim() || '#d1d5db';
+  slider.style.background = `linear-gradient(to right, ${active} 0%, ${active} ${percent}%, ${track} ${percent}%, ${track} 100%)`;
 }
 
 function updateMyAgeDisplay() {


### PR DESCRIPTION
﻿## 概要
- 为经典版补齐系统 / 浅色 / 深色三种主题切换，并让主题状态在全站保持一致
- 适配首页、问卷、设置/删除账号、后台、情侣匹配等经典页面的深色显示
- 收掉经典问卷页在主题切换后的细节问题，包括步骤条层级、滑块联动、主色一致性和地址栏 theme-color 同步

## 主要改动
- 在 `public/css/style.css` 中补充经典版主题变量、语义色和组件级 token
- 在公共头部与导航中加入经典版主题切换按钮，并同步 `aria-pressed`、`theme-color` 和系统主题跟随逻辑
- 将首页 Hero CTA、导航、提示条、匹配卡片、表格等切到主题变量
- 适配 `views/profile.ejs` 中的问卷、量表、分页步骤、LoveType 结果卡、区间滑块和主题联动脚本
- 适配 `views/password.ejs`、`views/delete-account.ejs`、`views/admin.ejs`、`views/couple-match.ejs` 的深色显示与语义色

## 本轮补充修复
- 首页未登录 CTA 不再写死浅色按钮样式，改为跟随主题变量
- 问卷页四个分节标题改为统一使用 `--primary`
- 问卷页步骤条在浅色 / 深色下重新整理层级，保证当前步骤、已完成步骤、未完成步骤都可区分
- 年龄范围和身高偏好滑块改成“双向联动，谁在拖谁保留”
- 滑块轨道统一改为读取 `--profile-slider-track`
- 后台“执行补跑”按钮改为使用 warning 语义前景色

## 验证
- `node --check app.js`
- 本地手工检查经典首页、注册页、问卷页、后台页的浅色 / 深色切换
