### PR TITLE
fix：优化移动端问卷与匹配结果页可用性

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -905,12 +905,48 @@ tr:hover td {
     border-radius: var(--radius);
   }
 
+  .mobile-menu-toggle {
+    display: block !important;
+  }
+
   .nav-links {
-    gap: 4px;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 260px;
+    background: var(--card);
+    flex-direction: column;
+    align-items: stretch;
+    padding: 0;
+    gap: 0;
+    z-index: 1000;
+    transform: translateX(100%);
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow: var(--shadow-lg);
+    overflow-y: auto;
+  }
+
+  .nav-links.open {
+    transform: translateX(0);
   }
 
   .nav-links > a:not(.btn) {
-    display: none;
+    display: block;
+    padding: 16px 24px;
+    border-bottom: 1px solid var(--border);
+    font-size: 1.05rem;
+    font-weight: 500;
+    color: var(--foreground);
+  }
+
+  .nav-links .btn {
+    margin: 20px 24px;
+    text-align: center;
+  }
+
+  .mobile-menu-close {
+    display: flex !important;
   }
 
   .theme-switch {
@@ -922,29 +958,39 @@ tr:hover td {
     font-size: 0.76rem;
   }
 
-  /* 移动端下拉菜单里的链接要显示 */
-  :root .dropdown-menu a {
-    display: block;
-  }
-
-  /* 移动端下拉菜单样式 */
   :root .dropdown {
-    display: inline-block;
+    display: block;
+    border-bottom: 1px solid var(--border);
   }
 
   :root .dropdown-toggle {
-    padding: 8px 12px;
+    width: 100%;
+    justify-content: space-between;
+    padding: 16px 24px;
+    font-size: 1.05rem;
+    font-weight: 500;
   }
 
   :root .dropdown-menu {
-    position: fixed;
-    top: 60px;
-    right: 8px;
-    left: auto;
-    width: auto;
-    min-width: 180px;
-    max-width: calc(100vw - 16px);
-    box-sizing: border-box;
+    position: static;
+    display: none;
+    box-shadow: none;
+    border: none;
+    border-radius: 0;
+    background: var(--muted);
+    padding: 0;
+    max-width: none;
+    margin: 0;
+  }
+  
+  :root .dropdown-menu.show {
+    display: block;
+  }
+
+  :root .dropdown-menu a {
+    display: block;
+    padding: 12px 32px;
+    border-bottom: 1px solid rgba(0,0,0,0.05);
   }
 
   .features {
@@ -1050,8 +1096,10 @@ tr:hover td {
   background: var(--muted);
 }
 
-.dropdown:hover .dropdown-menu {
-  display: block;
+@media (hover: hover) and (pointer: fine) {
+  .dropdown:hover .dropdown-menu {
+    display: block;
+  }
 }
 
 .dropdown-menu.show {

--- a/views/matches.ejs
+++ b/views/matches.ejs
@@ -9,6 +9,69 @@
   <% if (typeof isDev !== 'undefined' && isDev) { %>
   <link rel="stylesheet" href="/css/dev-tools.css">
   <% } %>
+  <style>
+    .match-list {
+      display: grid;
+      gap: 16px;
+    }
+    .match-card {
+      display: flex;
+      align-items: flex-start;
+      gap: 20px;
+      padding: 20px;
+      border-radius: 16px;
+      border: 1px solid var(--border);
+      background: var(--surface-soft);
+    }
+    .match-rank {
+      min-width: 50px;
+      font-size: 2rem;
+      font-weight: 700;
+      line-height: 1;
+      color: var(--primary);
+    }
+    .match-summary {
+      flex: 1;
+      min-width: 0;
+    }
+    .match-meta {
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+      margin-bottom: 8px;
+    }
+    .match-interest {
+      color: var(--muted-foreground);
+      font-size: 0.9rem;
+      overflow-wrap: anywhere;
+    }
+    .match-score {
+      align-self: center;
+      padding: 10px 14px;
+      border-radius: 999px;
+      font-weight: 700;
+      white-space: nowrap;
+    }
+    @media (max-width: 700px) {
+      .match-card {
+        flex-direction: column;
+        gap: 14px;
+      }
+      .match-rank {
+        min-width: 0;
+        font-size: 1.5rem;
+      }
+      .match-meta {
+        gap: 10px 12px;
+      }
+      .match-meta span {
+        min-width: calc(50% - 6px);
+      }
+      .match-score {
+        align-self: flex-start;
+      }
+    }
+  </style>
 </head>
 <body>
   <%- include('partials/navbar') %>
@@ -39,20 +102,20 @@
         这是本周已经发布并落库的正式匹配结果：
       </p>
 
-      <div style="display: grid; gap: 16px;">
+      <div class="match-list">
         <% matches.forEach(function(m, index) { %>
-        <div class="match-card" style="display: flex; align-items: center; gap: 20px; padding: 20px;">
-          <div style="font-size: 2rem; font-weight: 700; color: var(--primary); min-width: 50px;">
+        <div class="match-card">
+          <div class="match-rank">
             #<%= index + 1 %>
           </div>
-          <div style="flex: 1;">
-            <div style="display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 8px;">
+          <div class="match-summary">
+            <div class="match-meta">
               <span><strong>年级:</strong> <%= m.my_grade || '-' %></span>
               <span><strong>性别:</strong> <%= m.gender || '-' %></span>
               <span><strong>校区:</strong> <%= m.campus || '-' %></span>
               <span><strong>LoveType:</strong> <%= m.lovetype_code || '-' %></span>
             </div>
-            <div style="color: var(--muted-foreground); font-size: 0.9rem;">
+            <div class="match-interest">
               <strong>兴趣爱好:</strong> <%= m.interests || '-' %>
             </div>
           </div>

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -2,11 +2,28 @@
 <nav class="navbar">
   <div class="container">
     <a href="/" class="logo">心有所<span>SHU</span></a>
+    
+    <button class="mobile-menu-toggle" aria-label="打开菜单" aria-expanded="false" style="display: none; background: none; border: none; color: var(--foreground); cursor: pointer; padding: 4px;">
+      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="3" y1="12" x2="21" y2="12"></line>
+        <line x1="3" y1="6" x2="21" y2="6"></line>
+        <line x1="3" y1="18" x2="21" y2="18"></line>
+      </svg>
+    </button>
+    <div class="nav-overlay" style="display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 999; opacity: 0; transition: opacity 0.3s;"></div>
+
     <div class="nav-links">
+      <button class="mobile-menu-close" aria-label="关闭菜单" style="display: none; background: none; border: none; color: var(--foreground); cursor: pointer; padding: 16px; align-self: flex-end;">
+        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="18" y1="6" x2="6" y2="18"></line>
+          <line x1="6" y1="6" x2="18" y2="18"></line>
+        </svg>
+      </button>
+
       <a href="/">主页</a>
       <!-- 匹配下拉菜单 -->
       <div class="dropdown">
-        <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false" style="background: none; border: none; cursor: pointer; padding: 6px 12px; font-size: 0.9rem; color: var(--foreground); display: flex; align-items: center; gap: 4px;">
+        <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false" style="background: none; border: none; cursor: pointer; padding: 6px 12px; font-size: 0.9rem; color: var(--foreground); display: flex; align-items: center; justify-content: space-between; gap: 4px; width: 100%;">
           匹配
           <span style="font-size: 10px;">▼</span>
         </button>
@@ -30,7 +47,7 @@
       <% if (typeof user !== 'undefined' && user) { %>
         <!-- 昵称下拉菜单 -->
         <div class="dropdown">
-          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false" style="background: none; border: none; cursor: pointer; padding: 6px 12px; font-size: 0.9rem; color: var(--foreground); display: flex; align-items: center; gap: 4px;">
+          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false" style="background: none; border: none; cursor: pointer; padding: 6px 12px; font-size: 0.9rem; color: var(--foreground); display: flex; align-items: center; justify-content: space-between; gap: 4px; width: 100%;">
             <%= typeof nickname !== 'undefined' && nickname ? nickname : (user.name || user.email.split('@')[0]) %>
             <span style="font-size: 10px;">▼</span>
           </button>
@@ -83,9 +100,7 @@
   document.addEventListener('click', function(e) {
     var toggle = e.target.closest('.dropdown-toggle');
     if (toggle) {
-      if (!isTouchDropdownMode()) {
-        return;
-      }
+      if (!isTouchDropdownMode()) return;
       e.preventDefault();
       e.stopPropagation();
       var dropdown = toggle.closest('.dropdown');
@@ -102,6 +117,37 @@
       closeOpenMenus();
     }
   });
-})();
 
+  // 移动端菜单抽屉逻辑
+  var mobileToggle = document.querySelector('.mobile-menu-toggle');
+  var mobileClose = document.querySelector('.mobile-menu-close');
+  var navLinks = document.querySelector('.nav-links');
+  var navOverlay = document.querySelector('.nav-overlay');
+
+  function openMenu() {
+    navLinks.classList.add('open');
+    navOverlay.style.display = 'block';
+    setTimeout(() => navOverlay.style.opacity = '1', 10);
+    mobileToggle.setAttribute('aria-expanded', 'true');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeMenu() {
+    navLinks.classList.remove('open');
+    navOverlay.style.opacity = '0';
+    setTimeout(() => navOverlay.style.display = 'none', 300);
+    mobileToggle.setAttribute('aria-expanded', 'false');
+    document.body.style.overflow = '';
+  }
+
+  if (mobileToggle) {
+    mobileToggle.addEventListener('click', openMenu);
+  }
+  if (mobileClose) {
+    mobileClose.addEventListener('click', closeMenu);
+  }
+  if (navOverlay) {
+    navOverlay.addEventListener('click', closeMenu);
+  }
+})();
 </script>

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -89,7 +89,12 @@
       height: 6px;
       border-radius: 999px;
       background: var(--profile-slider-track);
-      outline: none;
+      outline: 2px solid transparent;
+      outline-offset: 4px;
+    }
+    .range-slider:focus-visible {
+      outline-color: var(--primary);
+      box-shadow: 0 0 0 4px var(--profile-surface-tint);
     }
     .range-slider::-webkit-slider-runnable-track {
       height: 6px;

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -84,6 +84,43 @@
     .range-slider {
       width: 100%;
       margin: 10px 0;
+      -webkit-appearance: none;
+      appearance: none;
+      height: 6px;
+      border-radius: 999px;
+      background: var(--profile-slider-track);
+      outline: none;
+    }
+    .range-slider::-webkit-slider-runnable-track {
+      height: 6px;
+      border-radius: 999px;
+      background: transparent;
+    }
+    .range-slider::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 24px;
+      height: 24px;
+      margin-top: -9px;
+      border-radius: 50%;
+      background: var(--profile-slider-thumb);
+      border: 3px solid var(--primary);
+      box-shadow: var(--profile-shadow);
+      cursor: pointer;
+    }
+    .range-slider::-moz-range-track {
+      height: 6px;
+      border-radius: 999px;
+      background: transparent;
+    }
+    .range-slider::-moz-range-thumb {
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      background: var(--profile-slider-thumb);
+      border: 3px solid var(--primary);
+      box-shadow: var(--profile-shadow);
+      cursor: pointer;
     }
     .range-labels {
       display: flex;
@@ -1695,45 +1732,51 @@
   .checkbox-group-grid {
     grid-template-columns: 1fr;
   }
+  .range-container {
+    padding: 14px 0 6px;
+  }
+  .range-slider {
+    margin: 14px 0 10px;
+  }
+  .range-labels {
+    font-size: 11px;
+  }
   .scale-horizontal {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 8px 4px;
-    align-items: end; 
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
   }
   .scale-label-left_text {
-    grid-column: 1;
-    grid-row: 1;
     text-align: left;
     width: auto;
     padding: 0;
   }
   .scale-label-right_text {
-    grid-column: 2;
-    grid-row: 1;
     text-align: right;
+    align-self: flex-end;
     width: auto;
     padding: 0;
   }
   .scale-options-row {
-    grid-column: 1 / 3;
-    grid-row: 2;
     width: 100%;
     min-width: 0;
     max-width: 100%;
+    justify-content: space-between;
+    gap: 6px;
   }
   .scale-option {
     max-width: none;
-    min-height: 44px;
+    min-height: 48px;
     justify-content: center;
-    padding: 6px 0;
+    padding: 8px 0;
   }
   .scale-option .scale-circle,
   .scale-circle {
-    width: 32px;
-    height: 32px;
-    min-width: 32px;
-    font-size: 11px;
+    width: 44px;
+    height: 44px;
+    min-width: 44px;
+    font-size: 13px;
   }
 }
 </style>


### PR DESCRIPTION
﻿## 概要
- 调整问卷页五档量表在窄屏下的布局，避免左右文案与选项断裂
- 放大移动端量表点击目标，并补强滑块在手机上的轨道与 thumb 样式
- 重排匹配结果页卡片布局，避免窄屏下信息被挤压或触发横向滚动

## 验证
- 变更范围仅限 `views/profile.ejs` 与 `views/matches.ejs`
- 重点覆盖 `#126` 中提到的移动端问卷和匹配结果页可用性问题

Closes #126
