### PR TITLE
fix(ui): 补充移动端菜单无障碍与缩放边界兜底，并修复导航栏毛玻璃层级 bug

### DIFF
--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -149,5 +149,19 @@
   if (navOverlay) {
     navOverlay.addEventListener('click', closeMenu);
   }
+
+  // 响应 Esc 键关闭抽屉菜单 (a11y)
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape' && navLinks && navLinks.classList.contains('open')) {
+      closeMenu();
+    }
+  });
+
+  // 窗口切回大屏时强制关闭菜单，防止遗留 overflow: hidden
+  window.addEventListener('resize', function() {
+    if (window.innerWidth > 768 && navLinks && navLinks.classList.contains('open')) {
+      closeMenu();
+    }
+  });
 })();
 </script>

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -123,19 +123,22 @@
   var mobileClose = document.querySelector('.mobile-menu-close');
   var navLinks = document.querySelector('.nav-links');
   var navOverlay = document.querySelector('.nav-overlay');
+  var overlayOpenTimeout, overlayCloseTimeout;
 
   function openMenu() {
+    clearTimeout(overlayCloseTimeout);
     navLinks.classList.add('open');
     navOverlay.style.display = 'block';
-    setTimeout(() => navOverlay.style.opacity = '1', 10);
+    overlayOpenTimeout = setTimeout(() => navOverlay.style.opacity = '1', 10);
     mobileToggle.setAttribute('aria-expanded', 'true');
     document.body.style.overflow = 'hidden';
   }
 
   function closeMenu() {
+    clearTimeout(overlayOpenTimeout);
     navLinks.classList.remove('open');
     navOverlay.style.opacity = '0';
-    setTimeout(() => navOverlay.style.display = 'none', 300);
+    overlayCloseTimeout = setTimeout(() => navOverlay.style.display = 'none', 300);
     mobileToggle.setAttribute('aria-expanded', 'false');
     document.body.style.overflow = '';
   }


### PR DESCRIPTION
补充 PR #129 遗漏的移动端抽屉菜单收口逻辑：
1. 响应 `Esc` 键关闭抽屉菜单 (a11y)
2. 窗口切回大屏时（resize）强制关闭菜单，防止遗留 `overflow: hidden` 导致页面卡死
3. 清理 overlay 的 setTimout 时序并发竞争残留
4. **【紧急修复】** 移除移动端 `.navbar` 的 `backdrop-filter: blur(10px)`。该属性会创建新的 containing block（包含块），导致内部绝对/固定定位的元素 (`.nav-links`) 相对 navbar 定位，而不是相对 Viewport，从而引发窄屏下菜单坍缩与溢出的严重布局错位 bug。