### PR TITLE
fix(ui): 紧急修复导航栏毛玻璃引起的移动端抽屉层级错乱

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -888,6 +888,11 @@ tr:hover td {
     padding: 16px;
   }
 
+  .navbar {
+    backdrop-filter: none;
+    background: var(--card);
+  }
+
   .navbar .container {
     padding: 12px 16px;
   }


### PR DESCRIPTION
（补提遗漏 commit）
移除移动端 `.navbar` 的 `backdrop-filter: blur(10px)`。该属性会创建新的 containing block（包含块），导致内部固定定位的元素 (`.nav-links`) 相对 navbar 定位而非 Viewport，从而引发严重的侧边栏菜单坍缩与溢出售 bug。