### PR TITLE
fix(ui): 修复移动端抽屉菜单主题切换组件排版问题并调整整体顺序

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -955,12 +955,14 @@ tr:hover td {
   }
 
   .theme-switch {
-    padding: 3px;
+    margin: 12px 24px;
+    padding: 4px;
+    align-self: flex-start;
   }
 
   .theme-switch__button {
-    padding: 6px 10px;
-    font-size: 0.76rem;
+    padding: 8px 16px;
+    font-size: 0.9rem;
   }
 
   :root .dropdown {

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -39,11 +39,6 @@
           <span class="notification-badge" style="position: absolute; top: -2px; right: -8px; background: var(--error); color: white; font-size: 10px; padding: 2px 5px; border-radius: 10px; min-width: 16px; text-align: center;"><%= notificationCount > 99 ? '99+' : notificationCount %></span>
         <% } %>
       </a>
-      <div class="theme-switch" role="group" aria-label="主题切换">
-        <button type="button" class="theme-switch__button" data-theme-option="light" aria-pressed="false">浅色</button>
-        <button type="button" class="theme-switch__button" data-theme-option="system" aria-pressed="false">系统</button>
-        <button type="button" class="theme-switch__button" data-theme-option="dark" aria-pressed="false">深色</button>
-      </div>
       <% if (typeof user !== 'undefined' && user) { %>
         <!-- 昵称下拉菜单 -->
         <div class="dropdown">
@@ -73,6 +68,11 @@
       <% } else { %>
         <a href="/login" class="btn" style="padding: 6px 14px; font-size: 0.85rem;">登录</a>
       <% } %>
+      <div class="theme-switch" role="group" aria-label="主题切换">
+        <button type="button" class="theme-switch__button" data-theme-option="light" aria-pressed="false">浅色</button>
+        <button type="button" class="theme-switch__button" data-theme-option="system" aria-pressed="false">系统</button>
+        <button type="button" class="theme-switch__button" data-theme-option="dark" aria-pressed="false">深色</button>
+      </div>
     </div>
   </div>
 </nav>

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -40,8 +40,8 @@
         <% } %>
       </a>
       <div class="theme-switch" role="group" aria-label="主题切换">
-        <button type="button" class="theme-switch__button" data-theme-option="system" aria-pressed="false">系统</button>
         <button type="button" class="theme-switch__button" data-theme-option="light" aria-pressed="false">浅色</button>
+        <button type="button" class="theme-switch__button" data-theme-option="system" aria-pressed="false">系统</button>
         <button type="button" class="theme-switch__button" data-theme-option="dark" aria-pressed="false">深色</button>
       </div>
       <% if (typeof user !== 'undefined' && user) { %>


### PR DESCRIPTION
1. **修复由于横向拉伸导致的主题切换组件变形问题**：在 flex-direction: column 的侧边栏中恢复了胶囊按钮的正确间距和宽度。
2. **调整抽屉内选项内部顺序**：将主题切换选项排序修正为：[浅色 | 系统 | 深色]。
3. **重新排列导航栏入口顺序**：将整体顺序调整为 **主页 -> 匹配 -> 通知 -> 个人 -> 模式切换**，将主题设置按钮放置在菜单最底端，符合交互习惯。