### PR TITLE
fix：恢复开发者工具一键登录并将问卷滑块回退为原生实现

### DIFF
--- a/app.js
+++ b/app.js
@@ -778,6 +778,40 @@ app.get('/login', (req, res) => {
   renderViewWithCsrf(req, res, 'login', { title: '登录', loginMethod: method, email, message: msg, messageType: type });
 });
 
+if (!isProduction) {
+  app.get('/dev/login/:prefix', wrapAsync(async (req, res) => {
+    const rawPrefix = typeof req.params.prefix === 'string' ? req.params.prefix.trim() : '';
+    const normalizedPrefix = rawPrefix.replace(/@shu\.edu\.cn$/i, '').toLowerCase();
+
+    if (!normalizedPrefix || !/^[a-z0-9._%+-]+$/i.test(normalizedPrefix)) {
+      return redirectWithMessage(res, '/login', '请输入合法的邮箱前缀');
+    }
+
+    const email = `${normalizedPrefix}@shu.edu.cn`;
+    let user = await findUserByEmailInsensitive(email);
+
+    if (!user) {
+      const defaultNickname = normalizedPrefix.slice(0, 24) || 'dev-user';
+      user = await db.queryOne(`
+        INSERT INTO users (email, verified, nickname)
+        VALUES ($1, 1, $2)
+        RETURNING id, email, nickname
+      `, [email, defaultNickname]);
+    }
+
+    if (!user?.id) {
+      return redirectWithMessage(res, '/login', '开发环境快捷登录失败');
+    }
+
+    await regenerateSession(req);
+    req.session.userId = user.id;
+    req.session.nickname = user.nickname || normalizedPrefix;
+    await saveSession(req);
+
+    return res.redirect('/');
+  }));
+}
+
 // 忘记密码页
 app.get('/forgot', (req, res) => {
   renderViewWithCsrf(req, res, 'forgot', {

--- a/public/css/dev-tools.css
+++ b/public/css/dev-tools.css
@@ -1,6 +1,6 @@
 .dev-tool-btn {
   position: fixed;
-  top: 15px;
+  bottom: 15px;
   right: 15px;
   width: 36px;
   height: 36px;
@@ -23,7 +23,7 @@
 .dev-modal {
   display: none;
   position: fixed;
-  top: 60px;
+  bottom: 60px;
   right: 15px;
   width: 300px;
   background: white;
@@ -35,11 +35,11 @@
 
 .dev-modal.show {
   display: block;
-  animation: slideDown 0.2s ease;
+  animation: slideUp 0.2s ease;
 }
 
-@keyframes slideDown {
-  from { opacity: 0; transform: translateY(-10px); }
+@keyframes slideUp {
+  from { opacity: 0; transform: translateY(10px); }
   to { opacity: 1; transform: translateY(0); }
 }
 
@@ -119,6 +119,23 @@
 .dev-btn.primary:hover {
   background: #764ba2;
   border-color: #764ba2;
+}
+
+.dev-input {
+  width: 100%;
+  padding: 10px 12px;
+  margin-bottom: 8px;
+  border: 1px solid #d8dce6;
+  border-radius: 8px;
+  background: #fff;
+  color: #1f2937;
+  font-size: 14px;
+  box-sizing: border-box;
+}
+
+.dev-input:focus {
+  outline: 2px solid rgba(102, 126, 234, 0.25);
+  border-color: #667eea;
 }
 
 .dev-info {

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <%- include('partials/head-icons') %>
   <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css">
+  <link rel="stylesheet" href="/css/dev-tools.css?v=bottom-right">
   <% } %>
 </head>
 <body>

--- a/views/confirm-match.ejs
+++ b/views/confirm-match.ejs
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <%- include('partials/head-icons') %>
   <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css">
+  <link rel="stylesheet" href="/css/dev-tools.css?v=bottom-right">
   <% } %>
 </head>
 <body>

--- a/views/couple-match.ejs
+++ b/views/couple-match.ejs
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <%- include('partials/head-icons') %>
   <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css">
+  <link rel="stylesheet" href="/css/dev-tools.css?v=bottom-right">
   <% } %>
 </head>
 <body>

--- a/views/couple-result.ejs
+++ b/views/couple-result.ejs
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <%- include('partials/head-icons') %>
   <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css">
+  <link rel="stylesheet" href="/css/dev-tools.css?v=bottom-right">
   <% } %>
 </head>
 <body>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <%- include('partials/head-icons') %>
   <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css">
+  <link rel="stylesheet" href="/css/dev-tools.css?v=bottom-right">
   <% } %>
 </head>
 <body>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <%- include('partials/head-icons') %>
   <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css">
+  <link rel="stylesheet" href="/css/dev-tools.css?v=bottom-right">
   <% } %>
 </head>
 <body>

--- a/views/matches.ejs
+++ b/views/matches.ejs
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <%- include('partials/head-icons') %>
   <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css">
+  <link rel="stylesheet" href="/css/dev-tools.css?v=bottom-right">
   <% } %>
   <style>
     .match-list {

--- a/views/notifications.ejs
+++ b/views/notifications.ejs
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <%- include('partials/head-icons') %>
   <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css">
+  <link rel="stylesheet" href="/css/dev-tools.css?v=bottom-right">
   <% } %>
 </head>
 <body>

--- a/views/partials/dev-tools.ejs
+++ b/views/partials/dev-tools.ejs
@@ -6,6 +6,17 @@
   </div>
   <div class="dev-modal-body">
     <div class="dev-section">
+      <div class="dev-section-title">快速登录</div>
+      <input
+        type="text"
+        id="devEmailInput"
+        class="dev-input"
+        placeholder="邮箱前缀（如 test、admin）"
+        onkeydown="if (event.key === 'Enter') { event.preventDefault(); devLogin(); }"
+      >
+      <button type="button" class="dev-btn primary" onclick="devLogin()">🚀 一键登录</button>
+    </div>
+    <div class="dev-section">
       <div class="dev-section-title">环境信息</div>
       <div class="dev-info"><strong>环境:</strong> <%= isProduction ? 'production' : 'development' %></div>
     </div>
@@ -21,6 +32,19 @@
     const modal = document.getElementById('devModal');
     modal.classList.toggle('show');
   }
+
+  function devLogin() {
+    const input = document.getElementById('devEmailInput');
+    const rawValue = input ? input.value.trim() : '';
+    if (!rawValue) {
+      alert('请输入邮箱前缀');
+      return;
+    }
+
+    const value = rawValue.replace(/@shu\.edu\.cn$/i, '');
+    window.location.href = '/dev/login/' + encodeURIComponent(value);
+  }
+
   document.addEventListener('click', function(e) {
     const modal = document.getElementById('devModal');
     const btn = document.querySelector('.dev-tool-btn');

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
     <%- include('partials/head-icons') %>
   <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css">
+  <link rel="stylesheet" href="/css/dev-tools.css?v=bottom-right">
   <% } %>
   <style>
     body.profile-page {
@@ -84,48 +84,10 @@
     .range-slider {
       width: 100%;
       margin: 10px 0;
-      -webkit-appearance: none;
-      appearance: none;
-      height: 6px;
-      border-radius: 999px;
-      background: var(--profile-slider-track);
-      outline: 2px solid transparent;
-      outline-offset: 4px;
     }
     .range-slider:focus-visible {
-      outline-color: var(--primary);
-      box-shadow: 0 0 0 4px var(--profile-surface-tint);
-    }
-    .range-slider::-webkit-slider-runnable-track {
-      height: 6px;
-      border-radius: 999px;
-      background: transparent;
-    }
-    .range-slider::-webkit-slider-thumb {
-      -webkit-appearance: none;
-      appearance: none;
-      width: 24px;
-      height: 24px;
-      margin-top: -9px;
-      border-radius: 50%;
-      background: var(--profile-slider-thumb);
-      border: 3px solid var(--primary);
-      box-shadow: var(--profile-shadow);
-      cursor: pointer;
-    }
-    .range-slider::-moz-range-track {
-      height: 6px;
-      border-radius: 999px;
-      background: transparent;
-    }
-    .range-slider::-moz-range-thumb {
-      width: 24px;
-      height: 24px;
-      border-radius: 50%;
-      background: var(--profile-slider-thumb);
-      border: 3px solid var(--primary);
-      box-shadow: var(--profile-shadow);
-      cursor: pointer;
+      outline: 2px solid var(--primary);
+      outline-offset: 2px;
     }
     .range-labels {
       display: flex;
@@ -1788,32 +1750,8 @@
 
 <script>
 
-// 滑块选择函数
-function calcPercent(val, min, max) {
-  return (val - min) / (max - min) * 100;
-}
-
-const sliderTheme = {
-  active: '#3b82f6',
-  track: '#d1d5db'
-};
-
-function refreshSliderTheme() {
-  const styles = getComputedStyle(document.body);
-  sliderTheme.active = styles.getPropertyValue('--info').trim() || '#3b82f6';
-  sliderTheme.track =
-    styles.getPropertyValue('--profile-slider-track').trim() ||
-    styles.getPropertyValue('--input').trim() ||
-    '#d1d5db';
-}
-
-function setSliderBg(slider, percent) {
-  slider.style.background = `linear-gradient(to right, ${sliderTheme.active} 0%, ${sliderTheme.active} ${percent}%, ${sliderTheme.track} ${percent}%, ${sliderTheme.track} 100%)`;
-}
-
 function updateMyAgeDisplay() {
   const s = document.getElementById('myAge');
-  setSliderBg(s, calcPercent(+s.value, 16, 30));
   document.getElementById('myAgeValue').textContent = s.value + ' 岁';
 }
 
@@ -1831,15 +1769,12 @@ function updateAgeRangeDisplay(changedSlider) {
       maxVal = minVal;
     }
   }
-  setSliderBg(minS, calcPercent(minVal, 16, 30));
-  setSliderBg(maxS, calcPercent(maxVal, 16, 30));
   document.getElementById('ageMinValue').textContent = '最小 ' + minVal + ' 岁';
   document.getElementById('ageMaxValue').textContent = '最大 ' + maxVal + ' 岁';
 }
 
 function updateMyHeightDisplay() {
   const s = document.getElementById('myHeight');
-  setSliderBg(s, calcPercent(+s.value, 140, 210)); 
   document.getElementById('myHeightValue').textContent = s.value + ' cm';
 }
 
@@ -1859,9 +1794,6 @@ function updatePreferredHeightDisplay(changedSlider) {
       maxVal = minVal;
     }
   }
-
-  setSliderBg(minSlider, calcPercent(minVal, 140, 210));
-  setSliderBg(maxSlider, calcPercent(maxVal, 140, 210));
 
   document.getElementById('preferredHeightMinValue').textContent = '最低 ' + minVal + ' cm';
   document.getElementById('preferredHeightMaxValue').textContent = '最高 ' + maxVal + ' cm';
@@ -1908,7 +1840,6 @@ document.addEventListener('DOMContentLoaded', function() {
   const surveyForm = document.querySelector('form[action="/survey/submit"]');
   if (!surveyForm) return;
 
-  refreshSliderTheme();
   updateMyAgeDisplay();
   updateAgeRangeDisplay();
   updateMyHeightDisplay();


### PR DESCRIPTION
﻿## 概要
- 恢复开发环境开发者工具中的一键登录入口
- 将开发者工具悬浮球和弹层整体移到右下角，避免遮挡右上角导航
- 将问卷页年龄/身高滑块回退为原生实现，去掉人工进度条与滑块位置脱节的问题

## 背景
- `#129` 已经合并，但本地联调时又发现了两类跟进问题：
  - 开发者工具缺少快捷登录，悬浮球位置也会挡住顶部菜单
  - 问卷页滑块在手机端和横屏/iPad 场景下，自定义进度条与原生 thumb 的几何不一致，视觉会露馅
- 这条 PR 只收这些后续调整，不再改 `#129` 已合入的其他移动端布局修复。

## 验证
- `node --check app.js`
- 本地打开 `/profile` 和开发者工具，确认：
  - 一键登录恢复
  - 悬浮球位于右下角
  - 滑块回到原生样式
