### PR TITLE
fix：收紧开发环境快捷登录入口并补齐可访问性

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,4 +14,5 @@ PORT=3000
 SESSION_SECRET=generate_a_random_string_here
 BASE_URL=http://localhost:3000
 ADMIN_EMAILS=admin@shu.edu.cn
+ENABLE_DEV_LOGIN=false
 NODE_ENV=production

--- a/.env.example
+++ b/.env.example
@@ -15,4 +15,5 @@ SESSION_SECRET=generate_a_random_string_here
 BASE_URL=http://localhost:3000
 ADMIN_EMAILS=admin@shu.edu.cn
 ENABLE_DEV_LOGIN=false
+DEV_LOGIN_ALLOW_PRIVATE_NETWORK=false
 NODE_ENV=production

--- a/app.js
+++ b/app.js
@@ -75,6 +75,37 @@ function redirectWithMessage(res, path, message, type = 'error') {
   return res.redirect(303, `${path}${separator}msg=${encodeURIComponent(message)}&type=${encodeURIComponent(type)}`);
 }
 
+function normalizeClientIpAddress(ip) {
+  if (typeof ip !== 'string') {
+    return '';
+  }
+
+  const trimmed = ip.trim().toLowerCase();
+  return trimmed.startsWith('::ffff:') ? trimmed.slice(7) : trimmed;
+}
+
+function isTrustedDevLoginIp(ip) {
+  if (!ip) {
+    return false;
+  }
+
+  return (
+    ip === '127.0.0.1' ||
+    ip === '::1' ||
+    ip === 'localhost' ||
+    /^10\./.test(ip) ||
+    /^192\.168\./.test(ip) ||
+    /^172\.(1[6-9]|2\d|3[0-1])\./.test(ip) ||
+    ip.startsWith('fc') ||
+    ip.startsWith('fd') ||
+    ip.startsWith('fe80:')
+  );
+}
+
+function isTrustedDevLoginRequest(req) {
+  return isTrustedDevLoginIp(normalizeClientIpAddress(req.ip || ''));
+}
+
 function escapeHtml(value) {
   return String(value)
     .replace(/&/g, '&amp;')
@@ -185,6 +216,7 @@ function resolveDeployTime() {
 let db = dbModule;
 const app = express();
 const isProduction = process.env.NODE_ENV === 'production';
+const devLoginEnabled = !isProduction && process.env.ENABLE_DEV_LOGIN === 'true';
 const sessionSecret = process.env.SESSION_SECRET;
 const appVersion = process.env.APP_VERSION || packageJson.version;
 const fullCommitSha = process.env.GIT_COMMIT || process.env.RENDER_GIT_COMMIT || null;
@@ -254,6 +286,8 @@ app.use(session({
 app.use((req, res, next) => {
   res.locals.isDev = !isProduction;
   res.locals.isProduction = isProduction;
+  res.locals.devLoginEnabled = devLoginEnabled && isTrustedDevLoginRequest(req);
+  res.locals.devLoginCsrfToken = res.locals.devLoginEnabled ? ensureCsrfToken(req) : null;
   next();
 });
 
@@ -490,6 +524,7 @@ const requireValidSettingsPasswordCsrf = createCsrfValidator('/settings/password
 const requireValidSurveyCsrf = createCsrfValidator('/profile');
 const requireValidCoupleMatchCsrf = createCsrfValidator('/couple-match');
 const requireValidNotificationsCsrf = createCsrfValidator('/notifications');
+const requireValidDevLoginCsrf = createCsrfValidator('/login?method=login');
 
 function renderSafely(res, status, view, locals = {}, fallbackMessage = '页面暂时不可用') {
   res.status(status).render(view, locals, (renderErr, html) => {
@@ -778,9 +813,13 @@ app.get('/login', (req, res) => {
   renderViewWithCsrf(req, res, 'login', { title: '登录', loginMethod: method, email, message: msg, messageType: type });
 });
 
-if (!isProduction) {
-  app.get('/dev/login/:prefix', wrapAsync(async (req, res) => {
-    const rawPrefix = typeof req.params.prefix === 'string' ? req.params.prefix.trim() : '';
+if (devLoginEnabled) {
+  app.post('/dev/login', requireValidDevLoginCsrf, wrapAsync(async (req, res) => {
+    if (!isTrustedDevLoginRequest(req)) {
+      return res.status(404).send('Not Found');
+    }
+
+    const rawPrefix = typeof req.body?.emailPrefix === 'string' ? req.body.emailPrefix.trim() : '';
     const normalizedPrefix = rawPrefix.replace(/@shu\.edu\.cn$/i, '').toLowerCase();
 
     if (!normalizedPrefix || !/^[a-z0-9._%+-]+$/i.test(normalizedPrefix)) {

--- a/app.js
+++ b/app.js
@@ -89,10 +89,15 @@ function isTrustedDevLoginIp(ip) {
     return false;
   }
 
+  if (ip === '127.0.0.1' || ip === '::1' || ip === 'localhost') {
+    return true;
+  }
+
+  if (process.env.DEV_LOGIN_ALLOW_PRIVATE_NETWORK !== 'true') {
+    return false;
+  }
+
   return (
-    ip === '127.0.0.1' ||
-    ip === '::1' ||
-    ip === 'localhost' ||
     /^10\./.test(ip) ||
     /^192\.168\./.test(ip) ||
     /^172\.(1[6-9]|2\d|3[0-1])\./.test(ip) ||
@@ -524,7 +529,7 @@ const requireValidSettingsPasswordCsrf = createCsrfValidator('/settings/password
 const requireValidSurveyCsrf = createCsrfValidator('/profile');
 const requireValidCoupleMatchCsrf = createCsrfValidator('/couple-match');
 const requireValidNotificationsCsrf = createCsrfValidator('/notifications');
-const requireValidDevLoginCsrf = createCsrfValidator('/login?method=login');
+const requireValidDevLoginCsrf = createCsrfValidator('/');
 
 function renderSafely(res, status, view, locals = {}, fallbackMessage = '页面暂时不可用') {
   res.status(status).render(view, locals, (renderErr, html) => {

--- a/app.js
+++ b/app.js
@@ -89,7 +89,7 @@ function isTrustedDevLoginIp(ip) {
     return false;
   }
 
-  if (ip === '127.0.0.1' || ip === '::1' || ip === 'localhost') {
+  if (/^127\./.test(ip) || ip === '::1' || ip === 'localhost') {
     return true;
   }
 
@@ -109,6 +109,33 @@ function isTrustedDevLoginIp(ip) {
 
 function isTrustedDevLoginRequest(req) {
   return isTrustedDevLoginIp(normalizeClientIpAddress(req.ip || ''));
+}
+
+function requireTrustedDevLoginSource(req, res, next) {
+  if (!isTrustedDevLoginRequest(req)) {
+    return res.status(404).send('Not Found');
+  }
+
+  return next();
+}
+
+function getSafeRefererPath(req, fallback = '/') {
+  const referer = req.get('referer');
+  if (!referer) {
+    return fallback;
+  }
+
+  try {
+    const refererUrl = new URL(referer);
+    const host = req.get('host');
+    if (!host || refererUrl.host !== host) {
+      return fallback;
+    }
+
+    return `${refererUrl.pathname}${refererUrl.search}`;
+  } catch {
+    return fallback;
+  }
 }
 
 function escapeHtml(value) {
@@ -819,16 +846,13 @@ app.get('/login', (req, res) => {
 });
 
 if (devLoginEnabled) {
-  app.post('/dev/login', requireValidDevLoginCsrf, wrapAsync(async (req, res) => {
-    if (!isTrustedDevLoginRequest(req)) {
-      return res.status(404).send('Not Found');
-    }
-
+  app.post('/dev/login', requireTrustedDevLoginSource, requireValidDevLoginCsrf, wrapAsync(async (req, res) => {
     const rawPrefix = typeof req.body?.emailPrefix === 'string' ? req.body.emailPrefix.trim() : '';
     const normalizedPrefix = rawPrefix.replace(/@shu\.edu\.cn$/i, '').toLowerCase();
+    const redirectPath = getSafeRefererPath(req, '/');
 
     if (!normalizedPrefix || !/^[a-z0-9._%+-]+$/i.test(normalizedPrefix)) {
-      return redirectWithMessage(res, '/login', '请输入合法的邮箱前缀');
+      return redirectWithMessage(res, redirectPath, '请输入合法的邮箱前缀');
     }
 
     const email = `${normalizedPrefix}@shu.edu.cn`;
@@ -844,7 +868,7 @@ if (devLoginEnabled) {
     }
 
     if (!user?.id) {
-      return redirectWithMessage(res, '/login', '开发环境快捷登录失败');
+      return redirectWithMessage(res, redirectPath, '开发环境快捷登录失败');
     }
 
     await regenerateSession(req);

--- a/public/css/dev-tools.css
+++ b/public/css/dev-tools.css
@@ -78,6 +78,10 @@
   margin-bottom: 0;
 }
 
+.dev-login-form {
+  margin: 0;
+}
+
 .dev-section-title {
   font-size: 12px;
   color: #888;
@@ -131,6 +135,14 @@
   color: #1f2937;
   font-size: 14px;
   box-sizing: border-box;
+}
+
+.dev-input-label {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 12px;
+  color: #555;
+  font-weight: 600;
 }
 
 .dev-input:focus {

--- a/views/partials/dev-tools.ejs
+++ b/views/partials/dev-tools.ejs
@@ -7,14 +7,29 @@
   <div class="dev-modal-body">
     <div class="dev-section">
       <div class="dev-section-title">快速登录</div>
-      <input
-        type="text"
-        id="devEmailInput"
-        class="dev-input"
-        placeholder="邮箱前缀（如 test、admin）"
-        onkeydown="if (event.key === 'Enter') { event.preventDefault(); devLogin(); }"
-      >
-      <button type="button" class="dev-btn primary" onclick="devLogin()">🚀 一键登录</button>
+      <% if (devLoginEnabled) { %>
+      <form method="post" action="/dev/login" class="dev-login-form">
+        <label for="devEmailInput" class="dev-input-label">学校邮箱前缀</label>
+        <input
+          type="hidden"
+          name="_csrf"
+          value="<%= devLoginCsrfToken %>"
+        >
+        <input
+          type="text"
+          id="devEmailInput"
+          name="emailPrefix"
+          class="dev-input"
+          placeholder="如 test、admin"
+          autocomplete="off"
+          autocapitalize="none"
+          spellcheck="false"
+        >
+        <button type="submit" class="dev-btn primary">🚀 一键登录</button>
+      </form>
+      <% } else { %>
+      <div class="dev-info">快捷登录已关闭。需要设置 <code>ENABLE_DEV_LOGIN=true</code>，并从本机或内网访问。</div>
+      <% } %>
     </div>
     <div class="dev-section">
       <div class="dev-section-title">环境信息</div>
@@ -31,18 +46,6 @@
   function toggleDevModal() {
     const modal = document.getElementById('devModal');
     modal.classList.toggle('show');
-  }
-
-  function devLogin() {
-    const input = document.getElementById('devEmailInput');
-    const rawValue = input ? input.value.trim() : '';
-    if (!rawValue) {
-      alert('请输入邮箱前缀');
-      return;
-    }
-
-    const value = rawValue.replace(/@shu\.edu\.cn$/i, '');
-    window.location.href = '/dev/login/' + encodeURIComponent(value);
   }
 
   document.addEventListener('click', function(e) {

--- a/views/partials/dev-tools.ejs
+++ b/views/partials/dev-tools.ejs
@@ -28,7 +28,7 @@
         <button type="submit" class="dev-btn primary">🚀 一键登录</button>
       </form>
       <% } else { %>
-      <div class="dev-info">快捷登录已关闭。需要设置 <code>ENABLE_DEV_LOGIN=true</code>，并从本机或内网访问。</div>
+      <div class="dev-info">快捷登录已关闭。需要设置 <code>ENABLE_DEV_LOGIN=true</code>；如需通过内网访问，还需额外设置 <code>DEV_LOGIN_ALLOW_PRIVATE_NETWORK=true</code>。</div>
       <% } %>
     </div>
     <div class="dev-section">


### PR DESCRIPTION
﻿## 概要
- 将开发环境快捷登录从直接改登录态的 GET 路由改成受控的 POST 表单提交
- 为快捷登录增加显式环境开关和本机/内网来源限制
- 补上快速登录输入框的可访问 label

## 背景
- `#134` 已合并，但合并前的 Copilot review 还遗留了两类问题：
  - `/dev/login/:prefix` 仅靠 `!isProduction` 暴露，并且用 GET 直接创建/切换登录态，风险过大
  - 开发者工具里的快速登录输入框缺少可访问标签
- 这条 follow-up 只收这两个点，不再动 `#134` 的其他视觉改动。

## 改动
- 仅在 `ENABLE_DEV_LOGIN=true` 时启用开发环境快捷登录
- 快捷登录改为 `POST /dev/login`，并复用现有 CSRF 校验
- 仅允许本机或内网来源使用该入口；不满足条件时返回 404
- 开发者工具中的快捷登录改成标准表单，并补上 label
- `.env.example` 增加 `ENABLE_DEV_LOGIN=false`

## 验证
- `node --check app.js`
