### PR TITLE
fix：让静态资源版本化构建支持重复执行

### DIFF
--- a/build.js
+++ b/build.js
@@ -53,25 +53,24 @@ function findEjsFiles(dir) {
   return files;
 }
 
-// 资源引用正则（匹配 href="/css/xxx.css" 或 src="/js/xxx.js" 等）
-const RESOURCE_REGEX = /(?:href|src)=["']([^"']+\.(?:css|js|jpe?g|png|svg|ico|webp|avif|gif))["']/g;
+// 资源引用正则（匹配 href="/css/xxx.css"、src="/js/xxx.js" 以及已带查询参数的版本化资源）
+const RESOURCE_REGEX = /(?:href|src)=["']([^"']+\.(?:css|js|jpe?g|png|svg|ico|webp|avif|gif)(?:\?[^"']*)?)["']/g;
 
 // 更新单个文件中的资源引用
 function updateResourceReferences(filePath, version) {
-  let content = fs.readFileSync(filePath, 'utf-8');
+  const content = fs.readFileSync(filePath, 'utf-8');
   let updated = false;
-  let match;
 
   const newContent = content.replace(RESOURCE_REGEX, (fullMatch, resourcePath) => {
-    // 排除已经有标准版本号格式的资源 (?v=数字.数字.数字)
-    // 但允许替换临时 hack 如 ?v=bottom-right
-    if (/^\?v=\d+\.\d+\.\d+/.test(resourcePath.split('?')[1])) {
+    const cleanPath = resourcePath.split('?')[0];
+    const nextPath = `${cleanPath}?v=${version}`;
+
+    if (resourcePath === nextPath) {
       return fullMatch;
     }
+
     updated = true;
-    // 移除现有的查询参数再添加新版本号
-    const cleanPath = resourcePath.split('?')[0];
-    return fullMatch.replace(resourcePath, `${cleanPath}?v=${version}`);
+    return fullMatch.replace(resourcePath, nextPath);
   });
 
   if (updated) {
@@ -84,13 +83,14 @@ function updateResourceReferences(filePath, version) {
 
 // 恢复原始引用（去掉版本号，用于下次构建前重置）
 function resetResourceReferences(filePath) {
-  let content = fs.readFileSync(filePath, 'utf-8');
+  const content = fs.readFileSync(filePath, 'utf-8');
   let updated = false;
 
   const newContent = content.replace(RESOURCE_REGEX, (fullMatch, resourcePath) => {
     if (resourcePath.includes('?v=')) {
       updated = true;
-      return fullMatch.replace(`?v=${VERSION}`, '').replace(resourcePath, resourcePath);
+      const cleanPath = resourcePath.split('?')[0];
+      return fullMatch.replace(resourcePath, cleanPath);
     }
     return fullMatch;
   });
@@ -106,7 +106,6 @@ function resetResourceReferences(filePath) {
 function main() {
   const args = process.argv.slice(2);
   const version = getVersion();
-  const VERSION = version; // 供 reset 使用
 
   console.log(`\n🔧 静态资源版本化构建`);
   console.log(`   版本: ${version}\n`);

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css?v=0.2.0">
   <%- include('partials/head-icons') %>
   <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css?v=bottom-right">
+  <link rel="stylesheet" href="/css/dev-tools.css?v=0.2.0">
   <% } %>
 </head>
 <body>

--- a/views/confirm-match.ejs
+++ b/views/confirm-match.ejs
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css?v=0.2.0">
   <%- include('partials/head-icons') %>
   <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css?v=bottom-right">
+  <link rel="stylesheet" href="/css/dev-tools.css?v=0.2.0">
   <% } %>
 </head>
 <body>

--- a/views/couple-match.ejs
+++ b/views/couple-match.ejs
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css?v=0.2.0">
   <%- include('partials/head-icons') %>
   <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css?v=bottom-right">
+  <link rel="stylesheet" href="/css/dev-tools.css?v=0.2.0">
   <% } %>
 </head>
 <body>

--- a/views/couple-result.ejs
+++ b/views/couple-result.ejs
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css?v=0.2.0">
   <%- include('partials/head-icons') %>
   <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css?v=bottom-right">
+  <link rel="stylesheet" href="/css/dev-tools.css?v=0.2.0">
   <% } %>
 </head>
 <body>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css?v=0.2.0">
   <%- include('partials/head-icons') %>
   <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css?v=bottom-right">
+  <link rel="stylesheet" href="/css/dev-tools.css?v=0.2.0">
   <% } %>
 </head>
 <body>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css?v=0.2.0">
   <%- include('partials/head-icons') %>
   <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css?v=bottom-right">
+  <link rel="stylesheet" href="/css/dev-tools.css?v=0.2.0">
   <% } %>
 </head>
 <body>

--- a/views/matches.ejs
+++ b/views/matches.ejs
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css?v=0.2.0">
   <%- include('partials/head-icons') %>
   <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css?v=bottom-right">
+  <link rel="stylesheet" href="/css/dev-tools.css?v=0.2.0">
   <% } %>
   <style>
     .match-list {

--- a/views/notifications.ejs
+++ b/views/notifications.ejs
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css?v=0.2.0">
   <%- include('partials/head-icons') %>
   <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css?v=bottom-right">
+  <link rel="stylesheet" href="/css/dev-tools.css?v=0.2.0">
   <% } %>
 </head>
 <body>

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css?v=0.2.0">
     <%- include('partials/head-icons') %>
   <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css?v=bottom-right">
+  <link rel="stylesheet" href="/css/dev-tools.css?v=0.2.0">
   <% } %>
   <style>
     body.profile-page {


### PR DESCRIPTION
﻿## 概要
- 修复 `build.js` 无法重复更新已带 `?v=` 版本号资源引用的问题
- 修复 `build:reset` 对当前模板基本无效的问题
- 将此前残留的 `?v=bottom-right` 之类临时参数收敛为统一的版本号形式

## 背景
`6279eaa` 把资源引用第一次改成了带 `?v=` 的形式，但 `build.js` 的正则只匹配不带查询参数的资源路径，导致：
- 再次执行 `node build.js` 时，大多数模板不会再被命中更新
- 执行 `node build.js --reset` 时，也无法把已有的 `?v=` 引用去掉
- 这意味着当前“资源版本化构建流程”并不是可重复执行的构建步骤，`#124` 也不应该在现状下关闭

## 改动
- 让 `build.js` 同时匹配：
  - 不带查询参数的资源引用
  - 已带 `?v=` 或其他查询参数的资源引用
- 更新构建逻辑：
  - 已有查询参数时也能统一改写成最新 `?v=<version>`
- 更新重置逻辑：
  - 能真正把现有 `?v=` 引用恢复为无版本号路径
- 用修正后的脚本重新生成当前模板中的资源引用

## 验证
- `node build.js --reset`
- `node build.js`
- `node build.js`
- `node build.js --reset`
- `node build.js`

Closes #124
