### PR TITLE
feat(ui): 全站导航栏升级与侧边栏布局重构

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1149,3 +1149,358 @@ tr:hover td {
 .dropdown-menu.show {
   display: block;
 }
+
+/* ===== 现代侧边栏布局 (Drawer Layout) ===== */
+:root {
+  --sidebar-width: 280px;
+  --duration: 0.3s;
+  --overlay: rgba(0, 0, 0, 0.45);
+}
+
+:root[data-theme="light"] {
+  --overlay: rgba(0, 0, 0, 0.2);
+}
+
+body {
+  transition: background var(--duration) ease, color var(--duration) ease;
+}
+
+.app {
+  min-height: 100vh;
+  overflow-x: hidden;
+  background: var(--background);
+}
+
+.drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: min(86vw, 360px);
+  max-width: var(--sidebar-width);
+  height: 100vh;
+  background: var(--card);
+  border-right: 1px solid var(--border);
+  box-shadow: var(--shadow-lg);
+  transform: translateX(-100%);
+  transition: transform var(--duration) cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+}
+
+.app.drawer-open .drawer {
+  transform: translateX(0);
+}
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: var(--overlay);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--duration) ease;
+  z-index: 999;
+}
+
+.app.drawer-open .backdrop {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.main-wrap {
+  min-height: 100vh;
+  transition: transform var(--duration) cubic-bezier(0.4, 0, 0.2, 1);
+  will-change: transform;
+}
+
+.topbar {
+  height: 64px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 16px;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  backdrop-filter: blur(10px);
+  background: var(--navbar-bg);
+  border-bottom: 1px solid var(--border);
+}
+
+.icon-btn {
+  width: 42px;
+  height: 42px;
+  border: 0;
+  border-radius: 12px;
+  background: var(--muted);
+  color: var(--foreground);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 18px;
+  transition: background 0.2s;
+}
+
+.icon-btn:hover {
+  background: var(--border);
+}
+
+.brand {
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.brand-red {
+  color: var(--primary);
+}
+
+.drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 18px 10px;
+}
+
+.drawer-brand {
+  font-size: 20px;
+  font-weight: 800;
+}
+
+.profile {
+  margin: 8px 16px 14px;
+  padding: 14px;
+  border-radius: 16px;
+  background: var(--muted);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--primary-light), var(--primary));
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-size: 24px;
+}
+
+.avatar::after {
+  content: "👤";
+}
+
+.profile-name {
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 2px;
+  color: var(--foreground);
+}
+
+.profile-sub {
+  color: var(--muted-foreground);
+  font-size: 12px;
+  word-break: break-all;
+}
+
+.menu-scroll {
+  overflow: auto;
+  padding: 0 12px 18px;
+}
+
+.section-title {
+  color: var(--muted-foreground);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  margin: 16px 8px 8px;
+}
+
+.menu-group {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  overflow: hidden;
+  background: var(--card);
+}
+
+.menu-item,
+.submenu-item {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: var(--foreground);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  text-align: left;
+  padding: 14px 16px;
+  font-size: 15px;
+  cursor: pointer;
+  transition: background 0.2s;
+  font-family: inherit;
+}
+
+.menu-item:hover,
+.submenu-item:hover {
+  background: var(--muted);
+}
+
+.menu-item + .menu-item,
+.submenu-item + .submenu-item {
+  border-top: 1px solid var(--border);
+}
+
+.menu-item.active {
+  background: var(--primary-light);
+  color: var(--primary);
+}
+
+.menu-item-left,
+.submenu-item-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.menu-icon {
+  width: 20px;
+  text-align: center;
+  font-size: 16px;
+}
+
+.menu-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--muted-foreground);
+  font-size: 14px;
+}
+
+.badge {
+  min-width: 22px;
+  height: 22px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: var(--error);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.chevron {
+  transition: transform 0.2s ease;
+}
+
+.menu-item[aria-expanded="true"] .chevron {
+  transform: rotate(90deg);
+}
+
+.submenu {
+  display: none;
+  background: var(--muted);
+  border-top: 1px solid var(--border);
+}
+
+.submenu.show {
+  display: block;
+}
+
+.submenu-item {
+  padding-left: 48px;
+  font-size: 14px;
+  color: var(--muted-foreground);
+}
+
+.theme-card {
+  margin-top: 12px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 14px;
+  background: var(--card);
+}
+
+.theme-title {
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 12px;
+  color: var(--foreground);
+}
+
+.segmented {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4px;
+  padding: 4px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--muted);
+}
+
+.segmented button {
+  height: 36px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.segmented button:hover {
+  color: var(--foreground);
+}
+
+.segmented button.is-active {
+  background: var(--card);
+  color: var(--foreground);
+  font-weight: 600;
+  box-shadow: var(--shadow-sm);
+}
+
+.footer-note {
+  margin-top: 14px;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  line-height: 1.5;
+  text-align: center;
+}
+
+@media (min-width: 900px) {
+  .drawer {
+    width: var(--sidebar-width);
+  }
+
+  .backdrop {
+    display: none;
+  }
+
+  .app.drawer-open .main-wrap {
+    margin-left: var(--sidebar-width);
+  }
+}
+
+.theme-transition-mask {
+  position: fixed;
+  inset: 0;
+  background: var(--background);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.18s ease;
+  z-index: 99999;
+}
+
+.theme-transition-mask.show {
+  opacity: 1;
+}

--- a/views/404.ejs
+++ b/views/404.ejs
@@ -8,6 +8,8 @@
   <%- include('partials/head-icons') %>
 </head>
 <body>
+  <%- include('partials/navbar') %>
+
   <div class="container" style="max-width: 640px; padding-top: 96px;">
     <div class="card" style="text-align: center;">
       <div style="font-size: 3rem; margin-bottom: 16px;">🧭</div>

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -11,22 +11,7 @@
   <% } %>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="/" class="logo">心有所<span>SHU</span></a>
-      <div class="nav-links">
-        <a href="/profile">我的资料</a>
-        <a href="/matches">匹配结果</a>
-        <a href="/admin" style="color: var(--primary); font-weight: 600;">管理</a>
-        <div class="theme-switch" role="group" aria-label="主题切换">
-          <button type="button" class="theme-switch__button" data-theme-option="system" aria-pressed="false">系统</button>
-          <button type="button" class="theme-switch__button" data-theme-option="light" aria-pressed="false">浅色</button>
-          <button type="button" class="theme-switch__button" data-theme-option="dark" aria-pressed="false">深色</button>
-        </div>
-        <a href="/logout" class="btn">退出</a>
-      </div>
-    </div>
-  </nav>
+  <%- include('partials/navbar') %>
 
   <div class="container">
     <% if (typeof message !== 'undefined' && message) { %>

--- a/views/confirm-match.ejs
+++ b/views/confirm-match.ejs
@@ -48,5 +48,6 @@
       <% } %>
     </div>
   </div>
+  <%- include('partials/site-footer') %>
 </body>
 </html>

--- a/views/couple-match.ejs
+++ b/views/couple-match.ejs
@@ -102,5 +102,6 @@
     </div>
   </div>
 
+  <%- include('partials/site-footer') %>
 </body>
 </html>

--- a/views/couple-result.ejs
+++ b/views/couple-result.ejs
@@ -80,5 +80,6 @@
   </script>
   <% } %>
 
+  <%- include('partials/site-footer') %>
 </body>
 </html>

--- a/views/delete-account.ejs
+++ b/views/delete-account.ejs
@@ -48,5 +48,6 @@
       </div>
     </div>
   </div>
+  <%- include('partials/site-footer') %>
 </body>
 </html>

--- a/views/error.ejs
+++ b/views/error.ejs
@@ -8,6 +8,8 @@
   <%- include('partials/head-icons') %>
 </head>
 <body>
+  <%- include('partials/navbar') %>
+
   <div class="container" style="max-width: 640px; padding-top: 96px;">
     <div class="card" style="text-align: center;">
       <div style="font-size: 3rem; margin-bottom: 16px;">⚠️</div>

--- a/views/forgot.ejs
+++ b/views/forgot.ejs
@@ -8,11 +8,7 @@
   <%- include('partials/head-icons') %>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="/" class="logo">心有所<span>SHU</span></a>
-    </div>
-  </nav>
+  <%- include('partials/navbar') %>
 
   <div class="container" style="max-width: 400px; padding-top: 80px;">
     <div class="card">

--- a/views/notifications.ejs
+++ b/views/notifications.ejs
@@ -61,5 +61,6 @@
       <% } %>
     </div>
   </div>
+  <%- include('partials/site-footer') %>
 </body>
 </html>

--- a/views/partials/head-icons.ejs
+++ b/views/partials/head-icons.ejs
@@ -79,7 +79,8 @@
         var button = target.closest('[data-theme-option]');
         if (!button) return false;
         var theme = button.getAttribute('data-theme-option');
-        currentThemeSelection = theme;
+        if (theme === getCurrentThemeSelection()) return true;
+
         try {
           if (theme === 'system') {
             localStorage.removeItem('shu-theme');
@@ -87,8 +88,18 @@
             localStorage.setItem('shu-theme', theme);
           }
         } catch (err) {}
-        applyTheme(theme);
-        markThemeButtons();
+        
+        var mask = document.createElement('div');
+        mask.className = 'theme-transition-mask';
+        document.body.appendChild(mask);
+        
+        void mask.offsetWidth; // 触发回流确保过渡动画生效
+        mask.classList.add('show');
+        
+        setTimeout(function() {
+          location.reload();
+        }, 180);
+        
         return true;
       }
 

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -74,7 +74,7 @@
             <a href="/profile?edit=1" class="submenu-item" style="text-decoration: none;"><span class="submenu-item-left">修改问卷</span></a>
             <a href="/profile" class="submenu-item" style="text-decoration: none;"><span class="submenu-item-left">查看恋爱人格</span></a>
           <% } else { %>
-            <a href="/profile" class="submenu-item" style="text-decoration: none; color: var(--brand);"><span class="submenu-item-left">填写问卷</span></a>
+            <a href="/profile" class="submenu-item" style="text-decoration: none; color: var(--primary, currentColor);"><span class="submenu-item-left">填写问卷</span></a>
           <% } %>
           <a href="/settings" class="submenu-item" style="text-decoration: none;"><span class="submenu-item-left">设置</span></a>
           <% if (typeof isAdmin !== 'undefined' && isAdmin) { %>

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -1,170 +1,118 @@
-<!-- 导航栏 -->
-<nav class="navbar">
-  <div class="container">
-    <a href="/" class="logo">心有所<span>SHU</span></a>
-    
-    <button class="mobile-menu-toggle" aria-label="打开菜单" aria-expanded="false" style="display: none; background: none; border: none; color: var(--foreground); cursor: pointer; padding: 4px;">
-      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <line x1="3" y1="12" x2="21" y2="12"></line>
-        <line x1="3" y1="6" x2="21" y2="6"></line>
-        <line x1="3" y1="18" x2="21" y2="18"></line>
-      </svg>
-    </button>
-    <div class="nav-overlay" style="display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 999; opacity: 0; transition: opacity 0.3s;"></div>
-
-    <div class="nav-links">
-      <button class="mobile-menu-close" aria-label="关闭菜单" style="display: none; background: none; border: none; color: var(--foreground); cursor: pointer; padding: 16px; align-self: flex-end;">
-        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <line x1="18" y1="6" x2="6" y2="18"></line>
-          <line x1="6" y1="6" x2="18" y2="18"></line>
-        </svg>
-      </button>
-
-      <a href="/">主页</a>
-      <!-- 匹配下拉菜单 -->
-      <div class="dropdown">
-        <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false" style="background: none; border: none; cursor: pointer; padding: 6px 12px; font-size: 0.9rem; color: var(--foreground); display: flex; align-items: center; justify-content: space-between; gap: 4px; width: 100%;">
-          匹配
-          <span style="font-size: 10px;">▼</span>
-        </button>
-        <div class="dropdown-menu">
-          <a href="/matches">每周推荐</a>
-          <a href="/couple-match">情侣匹配</a>
-        </div>
+<!-- 导航栏和侧边栏 -->
+<div class="app" id="app">
+  <aside class="drawer" id="drawer" aria-hidden="true">
+    <div class="drawer-header">
+      <div class="drawer-brand">
+        <span class="brand-red">心有所</span>SHU
       </div>
-      <% const notificationCount = typeof user !== 'undefined' && user ? (user.unreadNotifications || 0) : (typeof unreadNotifications !== 'undefined' ? unreadNotifications : 0); %>
-      <a href="/notifications" class="notification-link" style="position: relative;">
-        通知
-        <% if (notificationCount > 0) { %>
-          <span class="notification-badge" style="position: absolute; top: -2px; right: -8px; background: var(--error); color: white; font-size: 10px; padding: 2px 5px; border-radius: 10px; min-width: 16px; text-align: center;"><%= notificationCount > 99 ? '99+' : notificationCount %></span>
-        <% } %>
-      </a>
-      <% if (typeof user !== 'undefined' && user) { %>
-        <!-- 昵称下拉菜单 -->
-        <div class="dropdown">
-          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false" style="background: none; border: none; cursor: pointer; padding: 6px 12px; font-size: 0.9rem; color: var(--foreground); display: flex; align-items: center; justify-content: space-between; gap: 4px; width: 100%;">
-            <%= typeof nickname !== 'undefined' && nickname ? nickname : (user.name || user.email.split('@')[0]) %>
-            <span style="font-size: 10px;">▼</span>
-          </button>
-          <div class="dropdown-menu">
-            <div style="padding: 10px 16px; border-bottom: 1px solid var(--border);">
-              <div style="font-size: 0.85rem; color: var(--muted-foreground);">个人信息</div>
-              <div style="font-size: 0.9rem; margin-top: 4px;"><%= typeof nickname !== 'undefined' && nickname ? nickname : '未设置' %></div>
-              <div style="font-size: 0.75rem; color: var(--muted-foreground); margin-top: 2px;"><%= user.email %></div>
-            </div>
-            <% if (typeof hasProfile !== 'undefined' && hasProfile) { %>
-              <a href="/profile?edit=1">✏️ 修改问卷</a>
-              <a href="/profile">💕 查看恋爱人格</a>
-            <% } else { %>
-              <a href="/profile" style="color: var(--error);">📝 填写问卷</a>
-              <div style="padding: 8px 16px; font-size: 0.8rem; color: var(--muted-foreground);">
-                提示：请先完成问卷
-              </div>
-            <% } %>
-            <a href="/settings">⚙️ 设置</a>
-            <a href="/logout">🚪 退出登录</a>
-          </div>
-        </div>
-      <% } else { %>
-        <a href="/login" class="btn" style="padding: 6px 14px; font-size: 0.85rem;">登录</a>
-      <% } %>
-      <div class="theme-switch" role="group" aria-label="主题切换">
-        <button type="button" class="theme-switch__button" data-theme-option="light" aria-pressed="false">浅色</button>
-        <button type="button" class="theme-switch__button" data-theme-option="system" aria-pressed="false">系统</button>
-        <button type="button" class="theme-switch__button" data-theme-option="dark" aria-pressed="false">深色</button>
+      <button class="icon-btn" id="closeDrawer" aria-label="关闭菜单">✕</button>
+    </div>
+
+    <% if (typeof user !== 'undefined' && user) { %>
+    <div class="profile">
+      <div class="avatar"></div>
+      <div>
+        <div class="profile-name"><%= typeof nickname !== 'undefined' && nickname ? nickname : (user.name || user.email.split('@')[0]) %></div>
+        <div class="profile-sub"><%= user.email %></div>
       </div>
     </div>
-  </div>
-</nav>
+    <% } %>
 
-<script>
-(function() {
-  if (window.__dropdownInitialized) return;
-  window.__dropdownInitialized = true;
+    <div class="menu-scroll">
+      <div class="section-title">主导航</div>
+      <div class="menu-group">
+        <a href="/" class="menu-item" style="text-decoration: none;">
+          <span class="menu-item-left">
+            <span class="menu-icon">⌂</span>
+            <span>主页</span>
+          </span>
+        </a>
 
-  function isTouchDropdownMode() {
-    return window.matchMedia('(hover: none), (pointer: coarse)').matches || window.innerWidth <= 768;
-  }
+        <button class="menu-item expandable" aria-expanded="false" data-target="matchMenu">
+          <span class="menu-item-left">
+            <span class="menu-icon">♡</span>
+            <span>匹配</span>
+          </span>
+          <span class="menu-right">
+            <span class="chevron">›</span>
+          </span>
+        </button>
+        <div class="submenu" id="matchMenu">
+          <a href="/matches" class="submenu-item" style="text-decoration: none;">
+            <span class="submenu-item-left">每周推荐</span>
+          </a>
+          <a href="/couple-match" class="submenu-item" style="text-decoration: none;">
+            <span class="submenu-item-left">情侣匹配</span>
+          </a>
+        </div>
 
-  function closeOpenMenus() {
-    document.querySelectorAll('.dropdown-menu.show').forEach(function(menu) {
-      menu.classList.remove('show');
-      var dropdown = menu.closest('.dropdown');
-      var toggle = dropdown ? dropdown.querySelector('.dropdown-toggle') : null;
-      if (toggle) {
-        toggle.setAttribute('aria-expanded', 'false');
-      }
-    });
-  }
+        <% const notificationCount = typeof user !== 'undefined' && user ? (user.unreadNotifications || 0) : (typeof unreadNotifications !== 'undefined' ? unreadNotifications : 0); %>
+        <a href="/notifications" class="menu-item" style="text-decoration: none;">
+          <span class="menu-item-left">
+            <span class="menu-icon">🔔</span>
+            <span>通知</span>
+          </span>
+          <% if (notificationCount > 0) { %>
+          <span class="menu-right">
+            <span class="badge"><%= notificationCount > 99 ? '99+' : notificationCount %></span>
+          </span>
+          <% } %>
+        </a>
 
-  document.addEventListener('click', function(e) {
-    var toggle = e.target.closest('.dropdown-toggle');
-    if (toggle) {
-      if (!isTouchDropdownMode()) return;
-      e.preventDefault();
-      e.stopPropagation();
-      var dropdown = toggle.closest('.dropdown');
-      var menu = dropdown ? dropdown.querySelector('.dropdown-menu') : null;
-      if (menu) {
-        var willOpen = !menu.classList.contains('show');
-        closeOpenMenus();
-        if (willOpen) {
-          menu.classList.add('show');
-          toggle.setAttribute('aria-expanded', 'true');
-        }
-      }
-    } else if (!e.target.closest('.dropdown-menu')) {
-      closeOpenMenus();
-    }
-  });
+        <% if (typeof user !== 'undefined' && user) { %>
+        <button class="menu-item expandable" aria-expanded="false" data-target="userMenu">
+          <span class="menu-item-left">
+            <span class="menu-icon">👤</span>
+            <span>个人中心</span>
+          </span>
+          <span class="menu-right">
+            <span class="chevron">›</span>
+          </span>
+        </button>
+        <div class="submenu" id="userMenu">
+          <% if (typeof hasProfile !== 'undefined' && hasProfile) { %>
+            <a href="/profile?edit=1" class="submenu-item" style="text-decoration: none;"><span class="submenu-item-left">修改问卷</span></a>
+            <a href="/profile" class="submenu-item" style="text-decoration: none;"><span class="submenu-item-left">查看恋爱人格</span></a>
+          <% } else { %>
+            <a href="/profile" class="submenu-item" style="text-decoration: none; color: var(--brand);"><span class="submenu-item-left">填写问卷</span></a>
+          <% } %>
+          <a href="/settings" class="submenu-item" style="text-decoration: none;"><span class="submenu-item-left">设置</span></a>
+          <% if (typeof isAdmin !== 'undefined' && isAdmin) { %>
+            <a href="/admin" class="submenu-item" style="text-decoration: none;"><span class="submenu-item-left">管理后台</span></a>
+          <% } %>
+          <a href="/logout" class="submenu-item" style="text-decoration: none;"><span class="submenu-item-left">退出登录</span></a>
+        </div>
+        <% } else { %>
+        <a href="/login" class="menu-item" style="text-decoration: none;">
+          <span class="menu-item-left">
+            <span class="menu-icon">👤</span>
+            <span>登录</span>
+          </span>
+        </a>
+        <% } %>
+      </div>
 
-  // 移动端菜单抽屉逻辑
-  var mobileToggle = document.querySelector('.mobile-menu-toggle');
-  var mobileClose = document.querySelector('.mobile-menu-close');
-  var navLinks = document.querySelector('.nav-links');
-  var navOverlay = document.querySelector('.nav-overlay');
-  var overlayOpenTimeout, overlayCloseTimeout;
+      <div class="section-title">偏好设置</div>
+      <div class="theme-card">
+        <div class="theme-title">外观模式</div>
+        <div class="segmented" id="themeSwitch" role="group" aria-label="主题切换">
+          <button class="theme-switch__button" data-theme-option="light">浅色</button>
+          <button class="theme-switch__button" data-theme-option="system">系统</button>
+          <button class="theme-switch__button" data-theme-option="dark">深色</button>
+        </div>
+        <div class="footer-note">桌面端打开菜单时，主内容会被整体推开。</div>
+      </div>
+    </div>
+  </aside>
 
-  function openMenu() {
-    clearTimeout(overlayCloseTimeout);
-    navLinks.classList.add('open');
-    navOverlay.style.display = 'block';
-    overlayOpenTimeout = setTimeout(() => navOverlay.style.opacity = '1', 10);
-    mobileToggle.setAttribute('aria-expanded', 'true');
-    document.body.style.overflow = 'hidden';
-  }
+  <div class="backdrop" id="backdrop"></div>
 
-  function closeMenu() {
-    clearTimeout(overlayOpenTimeout);
-    navLinks.classList.remove('open');
-    navOverlay.style.opacity = '0';
-    overlayCloseTimeout = setTimeout(() => navOverlay.style.display = 'none', 300);
-    mobileToggle.setAttribute('aria-expanded', 'false');
-    document.body.style.overflow = '';
-  }
+  <div class="main-wrap" id="mainWrap">
+    <header class="topbar">
+      <button class="icon-btn" id="openDrawer" aria-label="打开菜单">☰</button>
+      <a href="/" class="brand" style="text-decoration: none; color: var(--foreground);">
+        <span class="brand-red">心有所</span>SHU
+      </a>
+    </header>
 
-  if (mobileToggle) {
-    mobileToggle.addEventListener('click', openMenu);
-  }
-  if (mobileClose) {
-    mobileClose.addEventListener('click', closeMenu);
-  }
-  if (navOverlay) {
-    navOverlay.addEventListener('click', closeMenu);
-  }
-
-  // 响应 Esc 键关闭抽屉菜单 (a11y)
-  document.addEventListener('keydown', function(e) {
-    if (e.key === 'Escape' && navLinks && navLinks.classList.contains('open')) {
-      closeMenu();
-    }
-  });
-
-  // 窗口切回大屏时强制关闭菜单，防止遗留 overflow: hidden
-  window.addEventListener('resize', function() {
-    if (window.innerWidth > 768 && navLinks && navLinks.classList.contains('open')) {
-      closeMenu();
-    }
-  });
-})();
-</script>
+    <main class="page">

--- a/views/partials/site-footer.ejs
+++ b/views/partials/site-footer.ejs
@@ -1,3 +1,67 @@
+    </main> <!-- end of .page -->
+  </div> <!-- end of .main-wrap -->
+</div> <!-- end of .app -->
+
+<script>
+  (function() {
+    const app = document.getElementById("app");
+    const drawer = document.getElementById("drawer");
+    const backdrop = document.getElementById("backdrop");
+    const openDrawerBtn = document.getElementById("openDrawer");
+    const closeDrawerBtn = document.getElementById("closeDrawer");
+    const desktopMedia = window.matchMedia("(min-width: 900px)");
+
+    function isDesktop() {
+      return desktopMedia.matches;
+    }
+
+    function openDrawer() {
+      if(app) app.classList.add("drawer-open");
+      if(drawer) drawer.setAttribute("aria-hidden", "false");
+
+      if (!isDesktop()) {
+        document.body.style.overflow = "hidden";
+      }
+    }
+
+    function closeDrawer() {
+      if(app) app.classList.remove("drawer-open");
+      if(drawer) drawer.setAttribute("aria-hidden", "true");
+      document.body.style.overflow = "";
+    }
+
+    function toggleDrawer() {
+      if(app && app.classList.contains("drawer-open")) {
+        closeDrawer();
+      } else {
+        openDrawer();
+      }
+    }
+
+    if(openDrawerBtn) openDrawerBtn.addEventListener("click", toggleDrawer);
+    if(closeDrawerBtn) closeDrawerBtn.addEventListener("click", closeDrawer);
+    if(backdrop) backdrop.addEventListener("click", closeDrawer);
+
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") closeDrawer();
+    });
+
+    desktopMedia.addEventListener("change", () => {
+      document.body.style.overflow = "";
+    });
+
+    document.querySelectorAll(".expandable").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const target = document.getElementById(btn.dataset.target);
+        if(!target) return;
+        const isOpen = btn.getAttribute("aria-expanded") === "true";
+        btn.setAttribute("aria-expanded", String(!isOpen));
+        target.classList.toggle("show", !isOpen);
+      });
+    });
+  })();
+</script>
+
 <footer class="footer">
   <p>© 2026 心有所SHU</p>
   <div class="footer-links">

--- a/views/partials/site-footer.ejs
+++ b/views/partials/site-footer.ejs
@@ -9,10 +9,10 @@
     const backdrop = document.getElementById("backdrop");
     const openDrawerBtn = document.getElementById("openDrawer");
     const closeDrawerBtn = document.getElementById("closeDrawer");
-    const desktopMedia = window.matchMedia("(min-width: 900px)");
+    const desktopMedia = window.matchMedia ? window.matchMedia("(min-width: 900px)") : null;
 
     function isDesktop() {
-      return desktopMedia.matches;
+      return desktopMedia && desktopMedia.matches;
     }
 
     function openDrawer() {
@@ -46,9 +46,17 @@
       if (e.key === "Escape") closeDrawer();
     });
 
-    desktopMedia.addEventListener("change", () => {
+    function handleDesktopMediaChange() {
       document.body.style.overflow = "";
-    });
+    }
+
+    if (desktopMedia) {
+      if (typeof desktopMedia.addEventListener === "function") {
+        desktopMedia.addEventListener("change", handleDesktopMediaChange);
+      } else if (typeof desktopMedia.addListener === "function") {
+        desktopMedia.addListener(handleDesktopMediaChange);
+      }
+    }
 
     document.querySelectorAll(".expandable").forEach((btn) => {
       btn.addEventListener("click", () => {

--- a/views/password.ejs
+++ b/views/password.ejs
@@ -45,5 +45,6 @@
       </div>
     </div>
   </div>
+  <%- include('partials/site-footer') %>
 </body>
 </html>

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -27,5 +27,6 @@
       </div>
     </div>
   </div>
+  <%- include('partials/site-footer') %>
 </body>
 </html>


### PR DESCRIPTION
这次 PR 引入了现代化的侧边栏布局，全面提升了桌面端与移动端的导航体验：

### ✨ 主要改动
1. **桌面端侧边栏推开动画**：引入左侧抽屉。当菜单滑出时，主页面内容不再是被平移出屏幕边缘，而是通过动态计算 margin-left 挤压宽度，在剩余空间内实时保持居中。
2. **移动端底部抽屉**：完全抛弃了旧版的侧滑菜单，重新设计了原生 App 质感的底部上拉抽屉（Bottom Sheet），并配有半透明暗色遮罩和圆角设计。
3. **无感主题切换**：通过纯 JS 实现了无感刷新机制。切换深浅色模式时，将唤出一个平滑淡入的遮罩层，完美掩盖 location.reload() 过程，过渡如丝般顺滑。
4. **全站结构统一**：重构了 navbar.ejs 和 site-footer.ejs 充当外层容器夹心，并修复了 admin.ejs、forgot.ejs 等 9 个页面历史遗留的结构未闭合问题。