### PR TITLE
[codex] 收口开发者工具视觉与 drawer 主题

### DIFF
--- a/public/css/dev-tools.css
+++ b/public/css/dev-tools.css
@@ -24,8 +24,7 @@
 
 .dev-tools-trigger:focus-visible,
 .dev-tools-close:focus-visible,
-.dev-tools-action:focus-visible,
-.dev-input:focus-visible {
+.dev-tools-action:focus-visible {
   outline: 3px solid var(--primary-light);
   outline-offset: 2px;
 }
@@ -271,6 +270,7 @@
   .app.drawer-open ~ .dev-tools-panel {
     opacity: 0;
     pointer-events: none;
+    visibility: hidden;
   }
 }
 

--- a/public/css/dev-tools.css
+++ b/public/css/dev-tools.css
@@ -1,169 +1,300 @@
-.dev-tool-btn {
+.dev-tools-trigger {
   position: fixed;
-  bottom: 15px;
-  right: 15px;
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
-  border: none;
-  cursor: pointer;
-  font-size: 16px;
-  box-shadow: 0 2px 10px rgba(102, 126, 234, 0.4);
-  z-index: 9999;
-  transition: transform 0.2s, box-shadow 0.2s;
-}
-
-.dev-tool-btn:hover {
-  transform: scale(1.1);
-  box-shadow: 0 4px 15px rgba(102, 126, 234, 0.6);
-}
-
-.dev-modal {
-  display: none;
-  position: fixed;
-  bottom: 60px;
-  right: 15px;
-  width: 300px;
-  background: white;
+  right: calc(18px + env(safe-area-inset-right));
+  bottom: calc(18px + env(safe-area-inset-bottom));
+  width: 44px;
+  height: 44px;
+  border: 1px solid var(--border);
   border-radius: 12px;
-  box-shadow: 0 10px 40px rgba(0,0,0,0.2);
-  z-index: 9998;
-  overflow: hidden;
-}
-
-.dev-modal.show {
-  display: block;
-  animation: slideUp 0.2s ease;
-}
-
-@keyframes slideUp {
-  from { opacity: 0; transform: translateY(10px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-.dev-modal-header {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
-  padding: 12px 16px;
-  font-weight: bold;
-  display: flex;
-  justify-content: space-between;
+  background: var(--card);
+  color: var(--foreground);
+  box-shadow: var(--shadow);
+  z-index: 998;
+  display: inline-flex;
   align-items: center;
-}
-
-.dev-modal-header .close-btn {
-  background: none;
-  border: none;
-  color: white;
-  font-size: 18px;
+  justify-content: center;
   cursor: pointer;
-  opacity: 0.8;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease, opacity 0.2s ease;
 }
 
-.dev-modal-header .close-btn:hover {
+.dev-tools-trigger:hover {
+  background: var(--muted);
+  transform: translateY(-1px);
+}
+
+.dev-tools-trigger:focus-visible,
+.dev-tools-close:focus-visible,
+.dev-tools-action:focus-visible,
+.dev-input:focus-visible {
+  outline: 3px solid var(--primary-light);
+  outline-offset: 2px;
+}
+
+.dev-tools-trigger[aria-expanded="true"] {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
+}
+
+.dev-tools-trigger__mark {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.dev-tools-panel {
+  position: fixed;
+  right: calc(18px + env(safe-area-inset-right));
+  bottom: calc(72px + env(safe-area-inset-bottom));
+  width: min(340px, calc(100vw - 32px));
+  max-height: min(560px, calc(100vh - 96px));
+  max-height: min(560px, calc(100svh - 96px));
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--card);
+  color: var(--foreground);
+  box-shadow: var(--shadow-lg);
+  z-index: 998;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(10px) scale(0.98);
+  transform-origin: bottom right;
+  transition: opacity 0.18s ease, transform 0.18s ease, visibility 0.18s ease;
+}
+
+.dev-tools-panel.show {
   opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0) scale(1);
 }
 
-.dev-modal-body {
-  padding: 16px;
+.dev-tools-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 16px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--card);
 }
 
-.dev-section {
-  margin-bottom: 16px;
+.dev-tools-eyebrow {
+  margin: 0 0 2px;
+  color: var(--primary);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0;
 }
 
-.dev-section:last-child {
-  margin-bottom: 0;
+.dev-tools-panel__header h2 {
+  margin: 0;
+  color: var(--foreground);
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1.3;
+  letter-spacing: 0;
+}
+
+.dev-tools-close {
+  flex: 0 0 auto;
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+}
+
+.dev-tools-panel__body {
+  overflow: auto;
+  padding: 14px 14px 16px;
+}
+
+.dev-tools-section + .dev-tools-section {
+  margin-top: 16px;
+}
+
+.dev-tools-section__title {
+  margin: 0 0 8px;
+  letter-spacing: 0;
 }
 
 .dev-login-form {
+  display: grid;
+  gap: 10px;
   margin: 0;
-}
-
-.dev-section-title {
-  font-size: 12px;
-  color: #888;
-  margin-bottom: 8px;
-  text-transform: uppercase;
-}
-
-.dev-btn {
-  display: block;
-  width: 100%;
-  padding: 10px 12px;
-  margin-bottom: 8px;
-  border: 1px solid #e0e0e0;
-  border-radius: 6px;
-  background: #f8f9fa;
-  color: #333;
-  text-decoration: none;
-  text-align: center;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.dev-btn:last-child {
-  margin-bottom: 0;
-}
-
-.dev-btn:hover {
-  background: #667eea;
-  color: white;
-  border-color: #667eea;
-}
-
-.dev-btn.primary {
-  background: #667eea;
-  color: white;
-  border-color: #667eea;
-}
-
-.dev-btn.primary:hover {
-  background: #764ba2;
-  border-color: #764ba2;
-}
-
-.dev-input {
-  width: 100%;
-  padding: 10px 12px;
-  margin-bottom: 8px;
-  border: 1px solid #d8dce6;
-  border-radius: 8px;
-  background: #fff;
-  color: #1f2937;
-  font-size: 14px;
-  box-sizing: border-box;
 }
 
 .dev-input-label {
   display: block;
-  margin-bottom: 6px;
-  font-size: 12px;
-  color: #555;
+  color: var(--muted-foreground);
+  font-size: 13px;
   font-weight: 600;
+  line-height: 1.4;
+}
+
+.dev-input {
+  width: 100%;
+  min-height: 42px;
+  padding: 10px 12px;
+  border: 1px solid var(--input);
+  border-radius: 12px;
+  background: var(--surface-elevated);
+  color: var(--foreground);
+  font: inherit;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.dev-input::placeholder {
+  color: var(--muted-foreground);
+  opacity: 0.78;
 }
 
 .dev-input:focus {
-  outline: 2px solid rgba(102, 126, 234, 0.25);
-  border-color: #667eea;
+  border-color: var(--primary);
+  outline: none;
 }
 
-.dev-info {
+.dev-input:focus-visible {
+  outline: 3px solid var(--primary-light);
+  outline-offset: 2px;
+}
+
+.dev-tools-actions {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--card);
+}
+
+.dev-tools-action {
+  width: 100%;
+  min-height: 42px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--foreground);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.dev-tools-action::after {
+  content: "›";
+  color: var(--muted-foreground);
+  font-size: 18px;
+  line-height: 1;
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.dev-tools-action:hover {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.dev-tools-action:hover::after {
+  color: var(--foreground);
+  transform: translateX(2px);
+}
+
+.dev-tools-action + .dev-tools-action {
+  border-top: 1px solid var(--border);
+}
+
+.dev-tools-action--primary {
+  justify-content: center;
+  border: 1px solid var(--primary);
+  border-radius: 12px;
+  background: var(--primary);
+  color: #fff;
+  text-align: center;
+}
+
+.dev-tools-action--primary::after {
+  display: none;
+}
+
+.dev-tools-action--primary:hover {
+  background: var(--primary-hover);
+  color: #fff;
+}
+
+.dev-tools-note {
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--muted);
+  color: var(--muted-foreground);
   font-size: 12px;
-  color: #666;
-  background: #f0f0f0;
-  padding: 8px 10px;
-  border-radius: 6px;
+  line-height: 1.6;
 }
 
-.dev-badge {
-  display: inline-block;
-  background: #4caf50;
-  color: white;
-  font-size: 10px;
-  padding: 2px 6px;
-  border-radius: 10px;
-  margin-left: 8px;
+.dev-tools-note code {
+  color: var(--foreground);
+  font-size: 0.95em;
+}
+
+.dev-tools-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 42px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--muted);
+  color: var(--muted-foreground);
+  font-size: 13px;
+}
+
+.dev-tools-status strong {
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+@media (max-width: 899px) {
+  .app.drawer-open ~ .dev-tools-trigger,
+  .app.drawer-open ~ .dev-tools-panel {
+    opacity: 0;
+    pointer-events: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .dev-tools-trigger {
+    right: calc(14px + env(safe-area-inset-right));
+    bottom: calc(14px + env(safe-area-inset-bottom));
+  }
+
+  .dev-tools-panel {
+    right: calc(12px + env(safe-area-inset-right));
+    bottom: calc(68px + env(safe-area-inset-bottom));
+    left: calc(12px + env(safe-area-inset-left));
+    width: auto;
+    max-height: min(560px, calc(100vh - 92px));
+    max-height: min(560px, calc(100svh - 92px));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dev-tools-trigger,
+  .dev-tools-panel,
+  .dev-tools-action,
+  .dev-tools-action::after {
+    transition: none;
+  }
 }

--- a/views/partials/dev-tools.ejs
+++ b/views/partials/dev-tools.ejs
@@ -1,12 +1,31 @@
-<button class="dev-tool-btn" onclick="toggleDevModal()" title="开发者工具">🔧</button>
-<div class="dev-modal" id="devModal">
-  <div class="dev-modal-header">
-    <span>🛠️ 开发者工具<span class="dev-badge">DEV</span></span>
-    <button class="close-btn" onclick="toggleDevModal()">×</button>
-  </div>
-  <div class="dev-modal-body">
-    <div class="dev-section">
-      <div class="dev-section-title">快速登录</div>
+<button
+  class="dev-tools-trigger"
+  id="devToolsTrigger"
+  type="button"
+  aria-label="打开开发者工具"
+  aria-controls="devToolsPanel"
+  aria-expanded="false"
+>
+  <span class="dev-tools-trigger__mark" aria-hidden="true">⚙</span>
+</button>
+
+<section
+  class="dev-tools-panel"
+  id="devToolsPanel"
+  aria-labelledby="devToolsTitle"
+  aria-hidden="true"
+>
+  <header class="dev-tools-panel__header">
+    <div>
+      <p class="dev-tools-eyebrow">DEV</p>
+      <h2 id="devToolsTitle">开发者工具</h2>
+    </div>
+    <button class="icon-btn dev-tools-close" type="button" aria-label="关闭开发者工具">✕</button>
+  </header>
+
+  <div class="dev-tools-panel__body">
+    <section class="dev-tools-section" aria-labelledby="devQuickLoginTitle">
+      <div class="section-title dev-tools-section__title" id="devQuickLoginTitle">快速登录</div>
       <% if (devLoginEnabled) { %>
       <form method="post" action="/dev/login" class="dev-login-form">
         <label for="devEmailInput" class="dev-input-label">学校邮箱前缀</label>
@@ -25,34 +44,91 @@
           autocapitalize="none"
           spellcheck="false"
         >
-        <button type="submit" class="dev-btn primary">🚀 一键登录</button>
+        <button type="submit" class="dev-tools-action dev-tools-action--primary">一键登录</button>
       </form>
       <% } else { %>
-      <div class="dev-info">快捷登录已关闭。需要设置 <code>ENABLE_DEV_LOGIN=true</code>；如需通过内网访问，还需额外设置 <code>DEV_LOGIN_ALLOW_PRIVATE_NETWORK=true</code>。</div>
+      <div class="dev-tools-note">
+        快捷登录已关闭。需要设置 <code>ENABLE_DEV_LOGIN=true</code>；如需通过内网访问，还需额外设置 <code>DEV_LOGIN_ALLOW_PRIVATE_NETWORK=true</code>。
+      </div>
       <% } %>
-    </div>
-    <div class="dev-section">
-      <div class="dev-section-title">环境信息</div>
-      <div class="dev-info"><strong>环境:</strong> <%= isProduction ? 'production' : 'development' %></div>
-    </div>
-    <div class="dev-section">
-      <div class="dev-section-title">快捷操作</div>
-      <a href="/admin" class="dev-btn">📊 管理后台</a>
-      <a href="/logout" class="dev-btn">🔓 退出登录</a>
-    </div>
-  </div>
-</div>
-<script>
-  function toggleDevModal() {
-    const modal = document.getElementById('devModal');
-    modal.classList.toggle('show');
-  }
+    </section>
 
-  document.addEventListener('click', function(e) {
-    const modal = document.getElementById('devModal');
-    const btn = document.querySelector('.dev-tool-btn');
-    if (modal && btn && !modal.contains(e.target) && !btn.contains(e.target)) {
-      modal.classList.remove('show');
+    <section class="dev-tools-section" aria-labelledby="devEnvironmentTitle">
+      <div class="section-title dev-tools-section__title" id="devEnvironmentTitle">环境信息</div>
+      <div class="dev-tools-status">
+        <span>当前环境</span>
+        <strong><%= isProduction ? 'production' : 'development' %></strong>
+      </div>
+    </section>
+
+    <section class="dev-tools-section" aria-labelledby="devActionsTitle">
+      <div class="section-title dev-tools-section__title" id="devActionsTitle">快捷操作</div>
+      <div class="dev-tools-actions">
+        <a href="/admin" class="dev-tools-action">管理后台</a>
+        <a href="/logout" class="dev-tools-action">退出登录</a>
+      </div>
+    </section>
+  </div>
+</section>
+
+<script>
+  (function() {
+    const trigger = document.getElementById('devToolsTrigger');
+    const panel = document.getElementById('devToolsPanel');
+    const closeButton = panel ? panel.querySelector('.dev-tools-close') : null;
+    const app = document.getElementById('app');
+
+    if (!trigger || !panel) return;
+
+    function setOpen(isOpen) {
+      panel.classList.toggle('show', isOpen);
+      panel.setAttribute('aria-hidden', String(!isOpen));
+      trigger.setAttribute('aria-expanded', String(isOpen));
+      trigger.setAttribute('aria-label', isOpen ? '关闭开发者工具' : '打开开发者工具');
+
+      if (isOpen) {
+        const input = panel.querySelector('.dev-input');
+        if (input && window.matchMedia && window.matchMedia('(min-width: 640px)').matches) {
+          input.focus();
+        }
+      }
     }
-  });
+
+    function isOpen() {
+      return panel.classList.contains('show');
+    }
+
+    trigger.addEventListener('click', function() {
+      setOpen(!isOpen());
+    });
+
+    if (closeButton) {
+      closeButton.addEventListener('click', function() {
+        setOpen(false);
+        trigger.focus();
+      });
+    }
+
+    document.addEventListener('click', function(e) {
+      if (!isOpen()) return;
+      if (panel.contains(e.target) || trigger.contains(e.target)) return;
+      setOpen(false);
+    });
+
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape' && isOpen()) {
+        setOpen(false);
+        trigger.focus();
+      }
+    });
+
+    if (app && window.MutationObserver) {
+      const observer = new MutationObserver(function() {
+        if (app.classList.contains('drawer-open')) {
+          setOpen(false);
+        }
+      });
+      observer.observe(app, { attributes: true, attributeFilter: ['class'] });
+    }
+  })();
 </script>


### PR DESCRIPTION
## 概要

- 将开发者工具 partial 改成更接近新版 drawer 的可访问面板，包含明确的打开/关闭状态、键盘 Esc 和外部点击关闭逻辑。
- 将开发者工具样式接入现有主题变量，使用当前的卡片、边框、主色、muted 和阴影体系，适配浅色、深色和系统主题。
- 保留快捷登录、管理后台跳转和退出登录能力，并在移动端导航抽屉打开时隐藏开发者工具，避免遮挡新版导航交互。

## 影响

开发环境里的工具面板会更贴合当前视觉系统，并且不再覆盖移动端 drawer/backdrop 交互层级。

## 验证

- `node --check app.js`
- `views/partials/dev-tools.ejs` 的 EJS 编译/渲染检查
- `git diff --check`