### PR TITLE
重构：普通页面复用公共 head

### DIFF
--- a/views/404.ejs
+++ b/views/404.ejs
@@ -1,11 +1,7 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><%= typeof title !== 'undefined' ? title : '页面不存在' %> - 心有所SHU</title>
-  <link rel="stylesheet" href="/css/style.css?v=0.2.0">
-  <%- include('partials/head-icons') %>
+  <%- include('partials/document-head', { pageTitle: typeof title !== 'undefined' ? title : '页面不存在' }) %>
 </head>
 <body>
   <%- include('partials/navbar') %>

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -1,14 +1,7 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>管理后台 - 心有所SHU</title>
-  <link rel="stylesheet" href="/css/style.css?v=0.2.0">
-  <%- include('partials/head-icons') %>
-  <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css?v=0.2.0">
-  <% } %>
+  <%- include('partials/document-head', { pageTitle: '管理后台', devToolsStyles: true }) %>
 </head>
 <body>
   <%- include('partials/navbar') %>

--- a/views/confirm-match.ejs
+++ b/views/confirm-match.ejs
@@ -1,14 +1,7 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>确认匹配 - 心有所SHU</title>
-  <link rel="stylesheet" href="/css/style.css?v=0.2.0">
-  <%- include('partials/head-icons') %>
-  <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css?v=0.2.0">
-  <% } %>
+  <%- include('partials/document-head', { pageTitle: '确认匹配', devToolsStyles: true }) %>
 </head>
 <body>
   <%- include('partials/navbar') %>

--- a/views/couple-match.ejs
+++ b/views/couple-match.ejs
@@ -1,14 +1,7 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>情侣匹配 - 心有所SHU</title>
-  <link rel="stylesheet" href="/css/style.css?v=0.2.0">
-  <%- include('partials/head-icons') %>
-  <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css?v=0.2.0">
-  <% } %>
+  <%- include('partials/document-head', { pageTitle: '情侣匹配', devToolsStyles: true }) %>
 </head>
 <body>
   <%- include('partials/navbar') %>

--- a/views/couple-result.ejs
+++ b/views/couple-result.ejs
@@ -1,14 +1,7 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>匹配结果 - 心有所SHU</title>
-  <link rel="stylesheet" href="/css/style.css?v=0.2.0">
-  <%- include('partials/head-icons') %>
-  <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css?v=0.2.0">
-  <% } %>
+  <%- include('partials/document-head', { pageTitle: '匹配结果', devToolsStyles: true }) %>
 </head>
 <body>
   <%- include('partials/navbar') %>

--- a/views/error.ejs
+++ b/views/error.ejs
@@ -1,11 +1,7 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><%= typeof title !== 'undefined' ? title : '服务器异常' %> - 心有所SHU</title>
-  <link rel="stylesheet" href="/css/style.css?v=0.2.0">
-  <%- include('partials/head-icons') %>
+  <%- include('partials/document-head', { pageTitle: typeof title !== 'undefined' ? title : '服务器异常' }) %>
 </head>
 <body>
   <%- include('partials/navbar') %>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,14 +1,7 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>心有所SHU - 上大交友匹配</title>
-  <link rel="stylesheet" href="/css/style.css?v=0.2.0">
-  <%- include('partials/head-icons') %>
-  <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css?v=0.2.0">
-  <% } %>
+  <%- include('partials/document-head', { fullTitle: '心有所SHU - 上大交友匹配', devToolsStyles: true }) %>
 </head>
 <body>
   <%- include('partials/navbar') %>

--- a/views/info-page.ejs
+++ b/views/info-page.ejs
@@ -1,11 +1,7 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><%= title %> - 心有所SHU</title>
-  <link rel="stylesheet" href="/css/style.css?v=0.2.0">
-  <%- include('partials/head-icons') %>
+  <%- include('partials/document-head', { fullTitle: title + ' - 心有所SHU' }) %>
 </head>
 <body>
   <%- include('partials/navbar') %>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -1,14 +1,7 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><%= typeof title !== 'undefined' ? title + ' - 心有所SHU' : '心有所SHU' %></title>
-  <link rel="stylesheet" href="/css/style.css?v=0.2.0">
-  <%- include('partials/head-icons') %>
-  <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css?v=0.2.0">
-  <% } %>
+  <%- include('partials/document-head', { devToolsStyles: true }) %>
 </head>
 <body>
   <nav class="navbar">

--- a/views/matches.ejs
+++ b/views/matches.ejs
@@ -1,14 +1,7 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>匹配结果 - 心有所SHU</title>
-  <link rel="stylesheet" href="/css/style.css?v=0.2.0">
-  <%- include('partials/head-icons') %>
-  <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css?v=0.2.0">
-  <% } %>
+  <%- include('partials/document-head', { pageTitle: '匹配结果', devToolsStyles: true }) %>
   <style>
     .match-list {
       display: grid;

--- a/views/notifications.ejs
+++ b/views/notifications.ejs
@@ -1,14 +1,7 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>通知中心 - 心有所SHU</title>
-  <link rel="stylesheet" href="/css/style.css?v=0.2.0">
-  <%- include('partials/head-icons') %>
-  <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css?v=0.2.0">
-  <% } %>
+  <%- include('partials/document-head', { pageTitle: '通知中心', devToolsStyles: true }) %>
 </head>
 <body>
   <%- include('partials/navbar') %>

--- a/views/partials/document-head.ejs
+++ b/views/partials/document-head.ejs
@@ -1,19 +1,24 @@
 <%
+  const providedFullTitle = typeof fullTitle !== 'undefined' && fullTitle ? fullTitle : '';
   const resolvedTitle = typeof pageTitle !== 'undefined' && pageTitle
     ? pageTitle
     : (typeof title !== 'undefined' && title ? title : '');
-  const documentTitle = resolvedTitle ? `${resolvedTitle} - 心有所SHU` : '心有所SHU';
+  const resolvedDocumentTitle = providedFullTitle || (resolvedTitle ? `${resolvedTitle} - 心有所SHU` : '心有所SHU');
   const includeAccountStyles = typeof accountPage !== 'undefined' && accountPage;
   const includeLoginTabsScript = typeof loginTabsScript !== 'undefined' && loginTabsScript;
+  const includeDevToolsStyles = typeof devToolsStyles !== 'undefined' && devToolsStyles && typeof isDev !== 'undefined' && isDev;
 %>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title><%= documentTitle %></title>
+<title><%= resolvedDocumentTitle %></title>
 <link rel="stylesheet" href="/css/style.css?v=0.2.0">
 <% if (includeAccountStyles) { %>
   <link rel="stylesheet" href="/css/account-pages.css?v=0.2.0">
 <% } %>
 <%- include('head-icons') %>
+<% if (includeDevToolsStyles) { %>
+  <link rel="stylesheet" href="/css/dev-tools.css?v=0.2.0">
+<% } %>
 <% if (includeLoginTabsScript) { %>
   <script src="/js/login-tabs.js?v=0.2.0" defer></script>
 <% } %>


### PR DESCRIPTION
Refs #125

## 更改
- 扩展 `views/partials/document-head.ejs`，支持完整标题覆盖和按需引入 dev tools 样式。
- 将首页、管理后台、匹配相关、通知页、说明页、错误页、旧 layout 等普通页面的重复 `<head>` 资源声明改为复用 `document-head`。
- 保留现有页面标题、`dev-tools.css` 引入行为和页面级 `<style>`，这次不改内容区样式与业务逻辑。

## 验证
- EJS 渲染冒烟：`404`、`error`、`info-page`、`index`、`admin`、`confirm-match`、`couple-match`、`couple-result`、`matches`、`notifications`、`layout` 以及账号相关页面。
- `git diff --check`
- 确认普通页面里基础 `meta/style.css` 重复只剩 `profile.ejs`，后续单独拆。