### PR TITLE
重构：外置匹配页面样式和评语脚本

### DIFF
--- a/.version.json
+++ b/.version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.2.0",
-  "generatedAt": "2026-04-23T12:36:34.039Z",
+  "generatedAt": "2026-04-24T02:35:16.470Z",
   "resources": {
     "css/account-pages.css": {
       "hash": "1b1d17ce",
@@ -11,8 +11,8 @@
       "version": "0.2.0-1fdea12d"
     },
     "css/style.css": {
-      "hash": "6d46d0bd",
-      "version": "0.2.0-6d46d0bd"
+      "hash": "0cd31def",
+      "version": "0.2.0-0cd31def"
     },
     "favicon.ico": {
       "hash": "5ecd6c3b",
@@ -37,6 +37,10 @@
     "images/campus.jpg": {
       "hash": "63b62764",
       "version": "0.2.0-63b62764"
+    },
+    "js/couple-result.js": {
+      "hash": "dacb5796",
+      "version": "0.2.0-dacb5796"
     },
     "js/layout-shell.js": {
       "hash": "2b474f11",

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -754,38 +754,109 @@ body {
 }
 
 /* ===== 匹配结果 ===== */
+.match-list {
+  display: grid;
+  gap: 16px;
+}
+
 .match-card {
-  background: var(--match-card-bg);
-  padding: 32px;
-  border-radius: var(--radius-lg);
-  text-align: center;
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
+  padding: 20px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: var(--surface-soft);
 }
 
-.match-card h3 {
-  font-size: 1.3rem;
-  font-weight: 600;
-  margin-bottom: 20px;
-  color: var(--foreground);
+.match-rank {
+  min-width: 50px;
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--primary);
 }
 
-.match-info {
-  background: var(--match-info-bg);
-  padding: 24px;
-  border-radius: var(--radius);
-  margin: 20px 0;
-  text-align: left;
+.match-summary {
+  flex: 1;
+  min-width: 0;
+}
+
+.match-meta {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+
+.match-interest {
+  color: var(--muted-foreground);
+  font-size: 0.9rem;
+  overflow-wrap: anywhere;
 }
 
 .match-score {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  background: var(--primary-light);
-  color: var(--primary);
-  padding: 8px 16px;
-  border-radius: 20px;
-  font-weight: 600;
-  font-size: 0.9rem;
+  align-self: center;
+  padding: 10px 14px;
+  border-radius: 999px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.match-score--high {
+  background: oklch(0.95 0.08 145);
+  color: oklch(0.4 0.12 145);
+}
+
+.match-score--medium {
+  background: oklch(0.95 0.08 80);
+  color: oklch(0.45 0.12 80);
+}
+
+.match-score--low {
+  background: oklch(0.95 0.08 25);
+  color: oklch(0.45 0.15 25);
+}
+
+.match-comment {
+  margin-bottom: 24px;
+  padding: 16px;
+  background: var(--accent);
+  border-radius: 8px;
+}
+
+.match-comment__title {
+  margin-bottom: 12px;
+}
+
+.match-comment__text {
+  margin: 0;
+  color: var(--muted-foreground);
+  line-height: 1.6;
+}
+
+@media (max-width: 700px) {
+  .match-card {
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .match-rank {
+    min-width: 0;
+    font-size: 1.5rem;
+  }
+
+  .match-meta {
+    gap: 10px 12px;
+  }
+
+  .match-meta span {
+    min-width: calc(50% - 6px);
+  }
+
+  .match-score {
+    align-self: flex-start;
+  }
 }
 
 /* ===== 表格 ===== */

--- a/public/js/couple-result.js
+++ b/public/js/couple-result.js
@@ -1,0 +1,44 @@
+(function() {
+  function setComment(container, message) {
+    var text = container.querySelector('[data-comment-text]');
+    if (!text) return;
+    text.textContent = message;
+  }
+
+  function initCoupleResultComment() {
+    var container = document.querySelector('[data-comment-url]');
+    if (!container) return;
+
+    var url = container.dataset.commentUrl;
+    if (!url) return;
+
+    fetch(url, {
+      headers: {
+        Accept: 'application/json'
+      }
+    })
+      .then(function(res) {
+        if (!res.ok) {
+          throw new Error('Failed to load match comment');
+        }
+        return res.json();
+      })
+      .then(function(data) {
+        var comment = data && typeof data.comment === 'string' ? data.comment.trim() : '';
+        if (data && data.success && comment) {
+          setComment(container, comment);
+          return;
+        }
+        setComment(container, '暂时无法生成评语');
+      })
+      .catch(function() {
+        setComment(container, '加载失败');
+      });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initCoupleResultComment, { once: true });
+  } else {
+    initCoupleResultComment();
+  }
+})();

--- a/views/couple-result.ejs
+++ b/views/couple-result.ejs
@@ -2,6 +2,9 @@
 <html lang="zh-CN">
 <head>
   <%- include('partials/document-head', { pageTitle: '匹配结果', devToolsStyles: true }) %>
+  <% if (!matchComment) { %>
+  <script src="/js/couple-result.js?v=0.2.0" defer></script>
+  <% } %>
 </head>
 <body>
   <%- include('partials/navbar') %>
@@ -24,14 +27,14 @@
       </div>
 
       <% if (typeof matchComment !== 'undefined' && matchComment) { %>
-      <div style="margin-bottom: 24px; padding: 16px; background: var(--accent); border-radius: 8px;">
-        <h3 style="margin-bottom: 16px;">匹配评语</h3>
-        <p style="margin: 0; color: var(--muted-foreground); line-height: 1.6;"><%= matchComment %></p>
+      <div class="match-comment">
+        <h3 class="match-comment__title">匹配评语</h3>
+        <p class="match-comment__text"><%= matchComment %></p>
       </div>
       <% } else { %>
-      <div id="comment-loading" style="margin-bottom: 24px; padding: 16px; background: var(--accent); border-radius: 8px;">
-        <h3 style="margin-bottom: 12px;">匹配评语</h3>
-        <p style="margin: 0; color: var(--muted-foreground);" data-comment-text>深度思考中...</p>
+      <div id="comment-loading" class="match-comment" data-comment-url="/api/couple-match/comment/<%= requestId %>">
+        <h3 class="match-comment__title">匹配评语</h3>
+        <p class="match-comment__text" data-comment-text>深度思考中...</p>
       </div>
       <% } %>
 
@@ -51,29 +54,6 @@
       </div>
     </div>
   </div>
-
-  <% if (!matchComment) { %>
-  <script>
-    (function() {
-      fetch('/api/couple-match/comment/<%= requestId %>')
-        .then(function(res) { return res.json(); })
-        .then(function(data) {
-          var container = document.getElementById('comment-loading');
-          var text = container.querySelector('[data-comment-text]');
-          if (data.success && data.comment) {
-            text.textContent = data.comment;
-          } else {
-            text.textContent = '暂时无法生成评语';
-          }
-        })
-        .catch(function() {
-          var container = document.getElementById('comment-loading');
-          var text = container.querySelector('[data-comment-text]');
-          text.textContent = '加载失败';
-        });
-    })();
-  </script>
-  <% } %>
 
   <%- include('partials/site-footer') %>
 </body>

--- a/views/matches.ejs
+++ b/views/matches.ejs
@@ -2,69 +2,6 @@
 <html lang="zh-CN">
 <head>
   <%- include('partials/document-head', { pageTitle: '匹配结果', devToolsStyles: true }) %>
-  <style>
-    .match-list {
-      display: grid;
-      gap: 16px;
-    }
-    .match-card {
-      display: flex;
-      align-items: flex-start;
-      gap: 20px;
-      padding: 20px;
-      border-radius: 16px;
-      border: 1px solid var(--border);
-      background: var(--surface-soft);
-    }
-    .match-rank {
-      min-width: 50px;
-      font-size: 2rem;
-      font-weight: 700;
-      line-height: 1;
-      color: var(--primary);
-    }
-    .match-summary {
-      flex: 1;
-      min-width: 0;
-    }
-    .match-meta {
-      display: flex;
-      gap: 16px;
-      flex-wrap: wrap;
-      margin-bottom: 8px;
-    }
-    .match-interest {
-      color: var(--muted-foreground);
-      font-size: 0.9rem;
-      overflow-wrap: anywhere;
-    }
-    .match-score {
-      align-self: center;
-      padding: 10px 14px;
-      border-radius: 999px;
-      font-weight: 700;
-      white-space: nowrap;
-    }
-    @media (max-width: 700px) {
-      .match-card {
-        flex-direction: column;
-        gap: 14px;
-      }
-      .match-rank {
-        min-width: 0;
-        font-size: 1.5rem;
-      }
-      .match-meta {
-        gap: 10px 12px;
-      }
-      .match-meta span {
-        min-width: calc(50% - 6px);
-      }
-      .match-score {
-        align-self: flex-start;
-      }
-    }
-  </style>
 </head>
 <body>
   <%- include('partials/navbar') %>
@@ -113,10 +50,8 @@
             </div>
           </div>
           <% if (m.score !== null && m.score !== undefined) { %>
-          <div class="match-score" style="
-            background: <%= m.score >= 0.7 ? 'oklch(0.95 0.08 145)' : m.score >= 0.5 ? 'oklch(0.95 0.08 80)' : 'oklch(0.95 0.08 25)' %>;
-            color: <%= m.score >= 0.7 ? 'oklch(0.4 0.12 145)' : m.score >= 0.5 ? 'oklch(0.45 0.12 80)' : 'oklch(0.45 0.15 25)' %>;
-          ">
+          <% const scoreTone = m.score >= 0.7 ? 'high' : (m.score >= 0.5 ? 'medium' : 'low'); %>
+          <div class="match-score match-score--<%= scoreTone %>">
             <%= Math.round(m.score * 100) %>%
           </div>
           <% } %>


### PR DESCRIPTION
## 变更内容
- 将 matches.ejs 的页面级匹配列表样式移入公共 style.css。
- 将匹配度徽章的内联颜色改为 CSS 状态类。
- 将 couple-result.ejs 的异步评语加载脚本抽到 public/js/couple-result.js。
- 异步评语改用 textContent 写入，避免继续拼接 innerHTML。
- 更新 .version.json，纳入新的 couple-result.js 和 style.css hash。

## 验证
- node --check public/js/couple-result.js
- git diff --check
- EJS render smoke：matches.ejs、couple-result.ejs 有/无 matchComment 三种路径

Refs #125