### PR TITLE
[codex] 修复上线前阻塞问题

### DIFF
--- a/matchService.js
+++ b/matchService.js
@@ -309,7 +309,7 @@ async function findMatches(userId, targetYear = null, targetWeek = null) {
       interests: candidate.interests,
       lovetype_code: candidate.lovetype_code,
       lovetype_label: lovetypeService.getCompatibilityLabel(myProfile.lovetype_code, candidate.lovetype_code),
-      score: Math.round(score / 100),
+      score: Math.round(score) / 100,
       score_ab: scoreAB,
       score_ba: scoreBA,
       score_breakdown: detailsA.breakdown
@@ -328,11 +328,6 @@ async function getTopMatches(userId, topN = 5, targetYear = null, targetWeek = n
 async function saveWeeklyMatches(targetYear = null, targetWeek = null) {
   const year = targetYear !== null ? targetYear : getYear();
   const weekNumber = targetWeek !== null ? targetWeek : getWeekNumber();
-
-  const existing = await dbModule.queryOne('SELECT id FROM matches WHERE match_year = $1 AND week_number = $2', [year, weekNumber]);
-  if (existing) {
-    return { success: false, message: '本周已执行匹配' };
-  }
 
   const users = await dbModule.query(`
     SELECT u.id, u.email, u.nickname, u.name, p.my_grade
@@ -357,10 +352,6 @@ async function saveWeeklyMatches(targetYear = null, targetWeek = null) {
 
     if (matches.length > 0) {
       const bestMatch = matches[0];
-      await dbModule.execute(`
-        INSERT INTO matches (user_id_1, user_id_2, score, week_number, match_year)
-        VALUES ($1, $2, $3, $4, $5)
-      `, [user.id, bestMatch.user_id, bestMatch.score, weekNumber, year]);
       matched.add(user.id);
       matched.add(bestMatch.user_id);
 
@@ -380,6 +371,32 @@ async function saveWeeklyMatches(targetYear = null, targetWeek = null) {
         }
       });
     }
+  }
+
+  try {
+    await dbModule.withTransaction(async (client) => {
+      await client.query('LOCK TABLE matches IN SHARE ROW EXCLUSIVE MODE');
+
+      const existing = await client.query(
+        'SELECT id FROM matches WHERE match_year = $1 AND week_number = $2 LIMIT 1',
+        [year, weekNumber]
+      );
+      if (existing.rowCount > 0) {
+        throw new Error('WEEKLY_MATCH_ALREADY_EXISTS');
+      }
+
+      for (const pair of results) {
+        await client.query(`
+          INSERT INTO matches (user_id_1, user_id_2, score, week_number, match_year)
+          VALUES ($1, $2, $3, $4, $5)
+        `, [pair.user1.id, pair.user2.id, pair.score, weekNumber, year]);
+      }
+    });
+  } catch (error) {
+    if (error.message === 'WEEKLY_MATCH_ALREADY_EXISTS') {
+      return { success: false, message: '本周已执行匹配' };
+    }
+    throw error;
   }
 
   return { success: true, message: `匹配完成，共 ${results.length} 对`, results };

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,9 +115,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -903,9 +903,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/peberminta": {

--- a/views/couple-match.ejs
+++ b/views/couple-match.ejs
@@ -12,7 +12,7 @@
 
       <% if (typeof message !== 'undefined' && message) { %>
         <div class="alert alert-<%= messageType || 'info' %>" style="margin-bottom: 20px;">
-          <%- message %>
+          <%= message %>
         </div>
       <% } %>
 

--- a/views/couple-result.ejs
+++ b/views/couple-result.ejs
@@ -12,7 +12,7 @@
 
       <% if (typeof message !== 'undefined' && message) { %>
         <div class="alert alert-<%= messageType || 'info' %>" style="margin-bottom: 20px;">
-          <%- message %>
+          <%= message %>
         </div>
       <% } %>
 
@@ -31,7 +31,7 @@
       <% } else { %>
       <div id="comment-loading" style="margin-bottom: 24px; padding: 16px; background: var(--accent); border-radius: 8px;">
         <h3 style="margin-bottom: 12px;">匹配评语</h3>
-        <p style="margin: 0; color: var(--muted-foreground);">深度思考中...</p>
+        <p style="margin: 0; color: var(--muted-foreground);" data-comment-text>深度思考中...</p>
       </div>
       <% } %>
 
@@ -59,15 +59,17 @@
         .then(function(res) { return res.json(); })
         .then(function(data) {
           var container = document.getElementById('comment-loading');
+          var text = container.querySelector('[data-comment-text]');
           if (data.success && data.comment) {
-            container.innerHTML = '<h3 style="margin-bottom: 12px;">匹配评语</h3><p style="margin: 0; color: var(--muted-foreground); line-height: 1.6;">' + data.comment + '</p>';
+            text.textContent = data.comment;
           } else {
-            container.innerHTML = '<h3 style="margin-bottom: 12px;">匹配评语</h3><p style="margin: 0; color: var(--muted-foreground);">暂时无法生成评语</p>';
+            text.textContent = '暂时无法生成评语';
           }
         })
         .catch(function() {
           var container = document.getElementById('comment-loading');
-          container.innerHTML = '<h3 style="margin-bottom: 12px;">匹配评语</h3><p style="margin: 0; color: var(--muted-foreground);">加载失败</p>';
+          var text = container.querySelector('[data-comment-text]');
+          text.textContent = '加载失败';
         });
     })();
   </script>


### PR DESCRIPTION
## 变更内容
- 修正正式匹配分数落库逻辑，避免 72 分被写成 1 并显示为 100%。
- 将周匹配落库改为事务内加锁、复查、批量插入，降低半套结果和并发重复写入风险。
- 修复情侣匹配相关页面的消息直出和异步评语 `innerHTML` 渲染风险。
- 更新 lockfile 中的 `path-to-regexp` 和 `brace-expansion`，清掉当前 npm audit 漏洞。

## 验证
- `node --check app.js`
- `node --check database.js`
- `node --check matchService.js`
- `npm audit --registry=https://registry.npmjs.org --omit=dev --audit-level=moderate`

## 备注
- 未连接真实数据库跑端到端流程；上线前仍建议用测试/生产环境跑一次注册、填问卷、确认匹配、执行匹配、查看结果的冒烟检查。