### PR TITLE
[codex] 隐藏每周匹配联系方式

### DIFF
--- a/app.js
+++ b/app.js
@@ -1769,7 +1769,6 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
       m.matched_at,
       m.match_comment,
       partner.id AS partner_id,
-      partner.email AS partner_email,
       partner.nickname AS partner_nickname,
       partner.name AS partner_name,
       p.my_grade AS partner_grade,
@@ -1798,8 +1797,7 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
     matchComment: weeklyMatches[0].match_comment,
     partner: {
       id: weeklyMatches[0].partner_id,
-      email: weeklyMatches[0].partner_email,
-      nickname: weeklyMatches[0].partner_nickname || weeklyMatches[0].partner_name || weeklyMatches[0].partner_email?.split('@')[0],
+      nickname: weeklyMatches[0].partner_nickname || weeklyMatches[0].partner_name || '同学',
       my_grade: weeklyMatches[0].partner_grade,
       gender: weeklyMatches[0].partner_gender,
       campus: weeklyMatches[0].partner_campus,
@@ -1840,7 +1838,6 @@ app.get('/matches/detail/:id', isLoggedIn, wrapAsync(async (req, res) => {
   const match = await db.queryOne(`
     SELECT m.*,
       partner.id AS partner_id,
-      partner.email AS partner_email,
       partner.nickname AS partner_nickname,
       partner.name AS partner_name,
       p.my_grade AS partner_grade,
@@ -1864,8 +1861,7 @@ app.get('/matches/detail/:id', isLoggedIn, wrapAsync(async (req, res) => {
 
   const partner = {
     id: match.partner_id,
-    email: match.partner_email,
-    nickname: match.partner_nickname || match.partner_name || match.partner_email?.split('@')[0],
+    nickname: match.partner_nickname || match.partner_name || '同学',
     my_grade: match.partner_grade,
     gender: match.partner_gender,
     campus: match.partner_campus,
@@ -1885,10 +1881,7 @@ app.get('/matches/detail/:id', isLoggedIn, wrapAsync(async (req, res) => {
       matchComment: match.match_comment,
       partner: partner
     },
-    matches: [{
-      ...partner,
-      email: partner.email
-    }],
+    matches: [partner],
     matchId: match.id,
     isAdmin: req.isAdmin,
     matchSource: 'weekly',
@@ -2272,6 +2265,15 @@ app.get('/couple-match/result/:id', isLoggedIn, wrapAsync(async (req, res) => {
 }));
 
 // API: 获取实时推荐列表
+function stripPublicMatchContactFields(match) {
+  const publicMatch = { ...match };
+  delete publicMatch.email;
+  delete publicMatch.partner_email;
+  delete publicMatch.requester_email;
+  delete publicMatch.receiver_email;
+  return publicMatch;
+}
+
 app.get('/api/matches', isLoggedIn, wrapAsync(async (req, res) => {
   // 检查是否确认参与匹配
   if (!req.user.weeklyMatchConfirmed) {
@@ -2279,7 +2281,7 @@ app.get('/api/matches', isLoggedIn, wrapAsync(async (req, res) => {
   }
   const matchService = require('./matchService');
   const matches = await matchService.findMatches(req.user.id, getYear(), getWeekNumber());
-  res.json({ success: true, source: 'recommendation', data: matches });
+  res.json({ success: true, source: 'recommendation', data: matches.map(stripPublicMatchContactFields) });
 }));
 
 // API: 获取前5名实时推荐
@@ -2290,7 +2292,7 @@ app.get('/api/match/top', isLoggedIn, wrapAsync(async (req, res) => {
   }
   const matchService = require('./matchService');
   const matches = await matchService.getTopMatches(req.user.id, 5, getYear(), getWeekNumber());
-  res.json({ success: true, source: 'recommendation', data: matches });
+  res.json({ success: true, source: 'recommendation', data: matches.map(stripPublicMatchContactFields) });
 }));
 
 // API: 异步获取匹配评语

--- a/views/match-detail.ejs
+++ b/views/match-detail.ejs
@@ -81,7 +81,7 @@
       <% if (matches && matches.length > 0) { %>
         <% var m = matches[0]; %>
         <div class="detail-score" style="background: var(--accent);">
-          <div class="label">与 <%= m.nickname || m.email %> 的匹配度</div>
+          <div class="label">与 <%= m.nickname || '同学' %> 的匹配度</div>
           <div class="score" style="color: <%= m.score >= 70 ? 'oklch(0.55 0.15 145)' : m.score >= 50 ? 'oklch(0.6 0.15 80)' : 'oklch(0.6 0.15 25)' %>;">
             <%= m.score !== null && m.score !== undefined ? Math.round(m.score) : '--' %>分
           </div>
@@ -106,7 +106,6 @@
           <p><span class="label">性别</span><span><%= m.gender || '未填写' %></span></p>
           <p><span class="label">校区</span><span><%= m.campus || '未填写' %></span></p>
           <p><span class="label">恋爱类型</span><span><%= m.lovetype_code || '未填写' %></span></p>
-          <p><span class="label">邮箱</span><span><%= m.email || '未填写' %></span></p>
         </div>
 
         <div class="detail-info">

--- a/views/matches.ejs
+++ b/views/matches.ejs
@@ -127,7 +127,7 @@
             #<%= index + 1 %>
           </div>
           <div style="flex: 1;">
-            <div>你的匹配对象是： <%= m.nickname || m.email %> </div>
+            <div>你的匹配对象是： <%= m.nickname || '同学' %> </div>
           </div>
           <% const scoreTone = m.score >= 70 ? 'high' : (m.score >= 50 ? 'medium' : 'low'); %>
           <div class="match-score match-score--<%= scoreTone %>">


### PR DESCRIPTION
## 背景

#146 合并后，每周匹配详情页会明确展示对方邮箱，列表和标题也会在昵称缺失时 fallback 到邮箱。这和每周匹配不直接暴露联系方式的产品预期不一致。

## 改动

- 每周匹配列表和详情查询不再读取 partner.email。
- 每周匹配页面不再显示邮箱，也不再用邮箱作为昵称 fallback。
- /api/matches 和 /api/match/top 返回前剥离 contact/email 字段，避免接口层继续暴露。

## 验证

- 
ode --check app.js
- 
ode --check matchService.js
- git diff --check
- EJS 渲染冒烟：带入 partner-secret@shu.edu.cn 后，每周匹配列表和详情 HTML 不包含该邮箱。