### PR TITLE
feat: 每周匹配以周二19点为分界

### DIFF
--- a/app.js
+++ b/app.js
@@ -1747,20 +1747,20 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
     return res.redirect('/profile');
   }
 
-  // 检查是否确认参与匹配
-  if (!req.user.weeklyMatchConfirmed) {
-    return res.redirect('/confirm-match?msg=请先确认参与本周匹配&type=warning');
-  }
-
   const weekInfo = getCurrentWeekByTuesday19();
+
+  // 查询当前周是否有匹配发布
   const weeklyRelease = await db.queryOne(
     'SELECT COUNT(*) as count FROM matches WHERE match_year = $1 AND week_number = $2',
     [weekInfo.year, weekInfo.week]
   );
   const hasWeeklyRelease = parseInt(weeklyRelease?.count || '0', 10) > 0;
-  const weeklyMatches = await db.query(`
+
+  // 查询用户所有历史匹配，按周倒序排列
+  const allMatches = await db.query(`
     SELECT
       m.id,
+      m.match_year,
       m.week_number,
       m.score,
       m.matched_at,
@@ -1781,30 +1781,28 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
         ELSE m.user_id_1
       END
     LEFT JOIN profiles p ON p.user_id = partner.id
-    WHERE m.match_year = $3 AND m.week_number = $2
-      AND ($1 = m.user_id_1 OR $1 = m.user_id_2)
-    ORDER BY m.matched_at DESC, m.id DESC
-    LIMIT 1
-  `, [req.user.id, weekNumber, matchYear]);
+    WHERE $1 = m.user_id_1 OR $1 = m.user_id_2
+    ORDER BY m.match_year DESC, m.week_number DESC
+  `, [req.user.id]);
 
-  const weeklyMatch = weeklyMatches.length > 0 ? {
-    weekNumber: weeklyMatches[0].week_number,
-    score: weeklyMatches[0].score,
-    matchedAt: weeklyMatches[0].matched_at,
-    matchId: weeklyMatches[0].id,
-    matchComment: weeklyMatches[0].match_comment,
+  const matchList = allMatches.map(row => ({
+    matchId: row.id,
+    year: row.match_year,
+    weekNumber: row.week_number,
+    score: row.score,
+    matchedAt: row.matched_at,
+    matchComment: row.match_comment,
     partner: {
-      id: weeklyMatches[0].partner_id,
-      email: weeklyMatches[0].partner_email,
-      nickname: weeklyMatches[0].partner_nickname || weeklyMatches[0].partner_name || weeklyMatches[0].partner_email?.split('@')[0],
-      my_grade: weeklyMatches[0].partner_grade,
-      gender: weeklyMatches[0].partner_gender,
-      campus: weeklyMatches[0].partner_campus,
-      interests: weeklyMatches[0].partner_interests,
-      lovetype_code: weeklyMatches[0].partner_lovetype_code,
-      score: weeklyMatches[0].score
+      id: row.partner_id,
+      email: row.partner_email,
+      nickname: row.partner_nickname || row.partner_name || row.partner_email?.split('@')[0],
+      my_grade: row.partner_grade,
+      gender: row.partner_gender,
+      campus: row.partner_campus,
+      interests: row.partner_interests,
+      lovetype_code: row.partner_lovetype_code
     }
-  } : null;
+  }));
 
   res.render('matches', {
     title: '匹配结果',
@@ -1812,14 +1810,12 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
     nickname: req.session.nickname,
     hasProfile: true,
     showPassword: true,
-    weeklyMatch: weeklyMatch,
-    matches: weeklyMatch ? [weeklyMatch.partner] : [],
-    matchId: weeklyMatch ? weeklyMatch.matchId : null,
+    matchList,
     isAdmin: req.isAdmin,
-    matchSource: 'weekly',
-    weekNumber,
+    weeklyMatchEnabled,
     hasWeeklyRelease,
-    weeklyMatchEnabled
+    currentWeekInfo: weekInfo,
+    weeklyMatchConfirmed: req.user.weeklyMatchConfirmed
   });
 }));
 

--- a/app.js
+++ b/app.js
@@ -1804,19 +1804,15 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
     }
   }));
 
-  // 构建本周状态条目
+  // 构建本周状态条目（仅已确认用户可见）
   const isCurrentWeek = weekInfo.year && weekInfo.week;
   const currentWeekMatch = matchList.find(m => m.year === weekInfo.year && m.weekNumber === weekInfo.week);
   let currentWeekEntry = null;
-  if (isCurrentWeek) {
-    if (req.user.weeklyMatchConfirmed) {
-      if (currentWeekMatch) {
-        currentWeekEntry = { ...currentWeekMatch, status: 'matched' };
-      } else {
-        currentWeekEntry = { year: weekInfo.year, weekNumber: weekInfo.week, status: 'no_match' };
-      }
+  if (isCurrentWeek && req.user.weeklyMatchConfirmed) {
+    if (currentWeekMatch) {
+      currentWeekEntry = { ...currentWeekMatch, status: 'matched' };
     } else {
-      currentWeekEntry = { year: weekInfo.year, weekNumber: weekInfo.week, status: 'not_confirmed' };
+      currentWeekEntry = { year: weekInfo.year, weekNumber: weekInfo.week, status: 'waiting' };
     }
   }
 

--- a/app.js
+++ b/app.js
@@ -1829,7 +1829,6 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
     nickname: req.session.nickname,
     hasProfile: true,
     showPassword: true,
-    matchList,
     historyList,
     currentWeekEntry,
     isAdmin: req.isAdmin,
@@ -1905,7 +1904,6 @@ app.get('/matches/detail/:id', isLoggedIn, wrapAsync(async (req, res) => {
     matchId: match.id,
     isAdmin: req.isAdmin,
     matchSource: 'weekly',
-    weekNumber,
     weeklyMatchEnabled
   });
 }));

--- a/app.js
+++ b/app.js
@@ -1804,6 +1804,25 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
     }
   }));
 
+  // 构建本周状态条目
+  const isCurrentWeek = weekInfo.year && weekInfo.week;
+  const currentWeekMatch = matchList.find(m => m.year === weekInfo.year && m.weekNumber === weekInfo.week);
+  let currentWeekEntry = null;
+  if (isCurrentWeek) {
+    if (req.user.weeklyMatchConfirmed) {
+      if (currentWeekMatch) {
+        currentWeekEntry = { ...currentWeekMatch, status: 'matched' };
+      } else {
+        currentWeekEntry = { year: weekInfo.year, weekNumber: weekInfo.week, status: 'no_match' };
+      }
+    } else {
+      currentWeekEntry = { year: weekInfo.year, weekNumber: weekInfo.week, status: 'not_confirmed' };
+    }
+  }
+
+  // 历史匹配（排除本周）
+  const historyList = matchList.filter(m => !(m.year === weekInfo.year && m.weekNumber === weekInfo.week));
+
   res.render('matches', {
     title: '匹配结果',
     user: req.user,
@@ -1811,6 +1830,8 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
     hasProfile: true,
     showPassword: true,
     matchList,
+    historyList,
+    currentWeekEntry,
     isAdmin: req.isAdmin,
     weeklyMatchEnabled,
     hasWeeklyRelease,

--- a/app.js
+++ b/app.js
@@ -7,7 +7,7 @@ const bcrypt = require('bcryptjs');
 const fs = require('fs');
 const path = require('path');
 const packageJson = require('./package.json');
-const { getWeekNumber, getYear } = require('./weekNumber');
+const { getWeekNumber, getYear, getCurrentWeekByTuesday19 } = require('./weekNumber');
 require('dotenv').config();
 const lovetypeService = require('./lovetypeService');
 const dbModule = require('./database');
@@ -380,11 +380,10 @@ async function loadCurrentUserFromSession(req) {
   );
 
   // 检查是否确认了本周的匹配（year + week 与当前周一致）
-  const currentYear = getYear();
-  const currentWeek = getWeekNumber();
+  const currentWeekInfo = getCurrentWeekByTuesday19();
   const weeklyMatchConfirmed = currentUser.weekly_match_year != null
-    && currentUser.weekly_match_year === currentYear
-    && currentUser.weekly_match_week === currentWeek;
+    && currentUser.weekly_match_year === currentWeekInfo.year
+    && currentUser.weekly_match_week === currentWeekInfo.week;
 
   const user = {
     id: currentUser.id,
@@ -1604,11 +1603,10 @@ app.post('/confirm-match', isLoggedIn, requireValidCsrf, wrapAsync(async (req, r
   }
 
   // 更新确认状态为当前 year + week
-  const currentYear = getYear();
-  const currentWeek = getWeekNumber();
+  const currentWeekInfo = getCurrentWeekByTuesday19();
   await db.execute(
     'UPDATE users SET weekly_match_year = $1, weekly_match_week = $2 WHERE id = $3',
-    [currentYear, currentWeek, req.user.id]
+    [currentWeekInfo.year, currentWeekInfo.week, req.user.id]
   );
 
   res.redirect('/?msg=已确认参与本周匹配&type=success');
@@ -1754,11 +1752,10 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
     return res.redirect('/confirm-match?msg=请先确认参与本周匹配&type=warning');
   }
 
-  const weekNumber = getWeekNumber();
-  const matchYear = getYear();
+  const weekInfo = getCurrentWeekByTuesday19();
   const weeklyRelease = await db.queryOne(
     'SELECT COUNT(*) as count FROM matches WHERE match_year = $1 AND week_number = $2',
-    [matchYear, weekNumber]
+    [weekInfo.year, weekInfo.week]
   );
   const hasWeeklyRelease = parseInt(weeklyRelease?.count || '0', 10) > 0;
   const weeklyMatches = await db.query(`
@@ -1833,8 +1830,7 @@ app.get('/matches/detail/:id', isLoggedIn, wrapAsync(async (req, res) => {
     return res.redirect('/matches');
   }
 
-  const weekNumber = getWeekNumber();
-  const matchYear = getYear();
+  const weekInfo = getCurrentWeekByTuesday19();
 
   // 查询匹配详情
   const match = await db.queryOne(`
@@ -2310,7 +2306,8 @@ app.get('/api/matches', isLoggedIn, wrapAsync(async (req, res) => {
     return res.status(403).json({ success: false, error: '请先确认参与本周匹配' });
   }
   const matchService = require('./matchService');
-  const matches = await matchService.findMatches(req.user.id, getYear(), getWeekNumber());
+  const weekInfo = getCurrentWeekByTuesday19();
+  const matches = await matchService.findMatches(req.user.id, weekInfo.year, weekInfo.week);
   res.json({ success: true, source: 'recommendation', data: matches });
 }));
 
@@ -2321,7 +2318,8 @@ app.get('/api/match/top', isLoggedIn, wrapAsync(async (req, res) => {
     return res.status(403).json({ success: false, error: '请先确认参与本周匹配' });
   }
   const matchService = require('./matchService');
-  const matches = await matchService.getTopMatches(req.user.id, 5, getYear(), getWeekNumber());
+  const weekInfo = getCurrentWeekByTuesday19();
+  const matches = await matchService.getTopMatches(req.user.id, 5, weekInfo.year, weekInfo.week);
   res.json({ success: true, source: 'recommendation', data: matches });
 }));
 
@@ -2431,11 +2429,13 @@ app.get('/admin', isLoggedIn, requireAdmin, wrapAsync(async (req, res) => {
     ORDER BY u.created_at DESC
   `);
 
+  const weekInfo = getCurrentWeekByTuesday19();
   res.render('admin', {
     title: '管理',
     user: req.user,
     users,
-    weekNumber: getWeekNumber(),
+    weekNumber: weekInfo.week,
+    year: weekInfo.year,
     csrfToken: ensureCsrfToken(req),
     message: req.query.msg,
     messageType: req.query.type,

--- a/matchService.js
+++ b/matchService.js
@@ -19,7 +19,7 @@
 
 const dbModule = require('./database');
 const lovetypeService = require('./lovetypeService');
-const { getWeekNumber, getYear } = require('./weekNumber');
+const { getWeekNumber, getYear, getCurrentWeekByTuesday19 } = require('./weekNumber');
 
 // ============ 工具函数 ============
 
@@ -380,8 +380,11 @@ async function getTopMatches(userId, topN = 5, targetYear = null, targetWeek = n
 }
 
 async function saveWeeklyMatches(targetYear = null, targetWeek = null) {
-  const year = targetYear !== null ? targetYear : getYear();
-  const weekNumber = targetWeek !== null ? targetWeek : getWeekNumber();
+  const weekInfo = targetYear !== null && targetWeek !== null
+    ? { year: targetYear, week: targetWeek }
+    : getCurrentWeekByTuesday19();
+  const year = weekInfo.year;
+  const weekNumber = weekInfo.week;
 
   const users = await dbModule.query(`
     SELECT u.id as user_id, u.email, u.nickname, u.name, p.my_grade

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -15,24 +15,17 @@
       <h1>心有所SHU</h1>
       <p class="subtitle">上大同学之间的互相认识，从这里开始</p>
       <p style="opacity: 0.7; font-size: 0.9rem;">小范围内测中</p>
-      <% if (typeof isMatchOpen !== 'undefined') { %>
-        <% if (isMatchOpen) { %>
-        <div class="countdown countdown--active">
-          <span class="countdown__label">本周匹配已开启</span>
-          <span class="countdown__time">快去看看吧</span>
-        </div>
-        <% } else if (typeof nextMatchTime !== 'undefined' && typeof now !== 'undefined') { %>
+      <% if (typeof nextMatchTime !== 'undefined' && typeof now !== 'undefined') { %>
         <% const timeLeft = nextMatchTime - now; %>
         <% const days = Math.floor(timeLeft / (1000 * 60 * 60 * 24)); %>
         <% const hours = Math.floor((timeLeft % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)); %>
         <% const minutes = Math.floor((timeLeft % (1000 * 60 * 60)) / (1000 * 60)); %>
         <div class="countdown">
-          <span class="countdown__label">每周二 19:00 开启匹配</span>
+          <span class="countdown__label">距离下周二 19:00</span>
           <span class="countdown__time">
             <% if (days > 0) { %><%= days %>天 <% } %><%= hours %>小时 <%= minutes %>分钟
           </span>
         </div>
-        <% } %>
       <% } %>
       <% if (typeof user === 'undefined' || !user) { %>
         <a href="/login" class="btn btn-large" style="margin-top: 20px;">开始</a>

--- a/views/matches.ejs
+++ b/views/matches.ejs
@@ -9,92 +9,67 @@
     }
     .match-card {
       display: flex;
-      align-items: flex-start;
-      gap: 20px;
-      padding: 20px;
+      align-items: center;
+      gap: 16px;
+      padding: 16px 20px;
       border-radius: 16px;
       border: 1px solid var(--border);
       background: var(--surface-soft);
     }
-    .match-rank {
-      min-width: 50px;
-      font-size: 2rem;
-      font-weight: 700;
-      line-height: 1;
-      color: var(--primary);
+    .match-card--current {
+      border-color: var(--primary);
+      border-width: 2px;
     }
-    .match-summary {
+    .match-card--no-match {
+      border-color: var(--border);
+    }
+    .match-week {
+      min-width: 90px;
+      font-weight: 700;
+      font-size: 1.1rem;
+    }
+    .match-info {
       flex: 1;
       min-width: 0;
     }
-    .match-meta {
-      display: flex;
-      gap: 16px;
-      flex-wrap: wrap;
-      margin-bottom: 8px;
+    .match-partner {
+      font-weight: 600;
+      margin-bottom: 4px;
     }
-    .match-interest {
+    .match-status {
+      font-size: 0.85rem;
       color: var(--muted-foreground);
-      font-size: 0.9rem;
-      overflow-wrap: anywhere;
+    }
+    .match-status--warn {
+      color: var(--warning);
+    }
+    .match-status--wait {
+      color: var(--primary);
     }
     .match-score {
-      align-self: center;
-      padding: 10px 14px;
+      padding: 8px 14px;
       border-radius: 999px;
       font-weight: 700;
       white-space: nowrap;
     }
-    .match-comment {
-      margin-top: 16px;
-      padding: 16px;
-      border-radius: 12px;
-      background: var(--surface);
-      border: 1px solid var(--border);
-    }
-    .match-comment p {
-      margin: 0 0 8px 0;
-    }
-    .match-comment p:last-child {
-      margin-bottom: 0;
-    }
-    .match-comment-loading {
-      text-align: center;
-      color: var(--muted-foreground);
-      font-size: 0.9rem;
-      padding: 20px;
-    }
-    .week-badge {
+    .match-detail-link {
       display: inline-block;
-      padding: 3px 10px;
-      border-radius: 999px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      background: var(--primary);
-      color: #fff;
-      opacity: 0.85;
+      margin-top: 6px;
+      font-size: 0.85rem;
+      color: var(--primary);
+      text-decoration: none;
     }
-    .week-badge--current {
-      background: var(--success);
-      opacity: 1;
+    .match-detail-link:hover {
+      text-decoration: underline;
     }
     @media (max-width: 700px) {
       .match-card {
         flex-direction: column;
-        gap: 14px;
+        align-items: flex-start;
+        gap: 10px;
       }
-      .match-rank {
+      .match-week {
         min-width: 0;
-        font-size: 1.5rem;
-      }
-      .match-meta {
-        gap: 10px 12px;
-      }
-      .match-meta span {
-        min-width: calc(50% - 6px);
-      }
-      .match-score {
-        align-self: flex-start;
       }
     }
   </style>
@@ -129,47 +104,88 @@
       <p style="color: var(--muted-foreground); margin-bottom: 24px;">确认后即可查看历史匹配记录和参与本周匹配。</p>
       <a href="/confirm-match" class="btn btn-large">确认参与匹配</a>
     </div>
-    <% } else if (!matchList || matchList.length === 0) { %>
+    <% } else { %>
+
+    <% if (currentWeekEntry) { %>
+    <div class="card">
+      <h3 style="margin: 0 0 16px 0; display: flex; align-items: center; gap: 8px;">
+        <span>本周</span>
+      </h3>
+      <% if (currentWeekEntry.status === 'matched') { %>
+      <a href="/matches/detail/<%= currentWeekEntry.matchId %>" class="match-card match-card--current" style="text-decoration: none; color: inherit;">
+        <div class="match-week">第<%= currentWeekEntry.weekNumber %>周</div>
+        <div class="match-info">
+          <div class="match-partner"><%= currentWeekEntry.partner.nickname || currentWeekEntry.partner.email %></div>
+          <% if (currentWeekEntry.score !== null && currentWeekEntry.score !== undefined) { %>
+          <% const scoreTone = currentWeekEntry.score >= 70 ? 'high' : (currentWeekEntry.score >= 50 ? 'medium' : 'low'); %>
+          <div class="match-score match-score--<%= scoreTone %>" style="display: inline-block; margin-top: 4px;">
+            <%= Math.round(currentWeekEntry.score) %>分
+          </div>
+          <% } %>
+        </div>
+        <div style="color: var(--muted-foreground); font-size: 0.85rem;">查看详情 →</div>
+      </a>
+      <% } else if (currentWeekEntry.status === 'no_match') { %>
+      <div class="match-card match-card--no-match">
+        <div class="match-week">第<%= currentWeekEntry.weekNumber %>周</div>
+        <div class="match-info">
+          <div class="match-partner" style="color: var(--muted-foreground);">抱歉，未能匹配到合适的对象</div>
+          <div class="match-status">下周再来试试吧~</div>
+        </div>
+      </div>
+      <% } else if (currentWeekEntry.status === 'not_confirmed') { %>
+      <div class="match-card match-card--no-match">
+        <div class="match-week">第<%= currentWeekEntry.weekNumber %>周</div>
+        <div class="match-info">
+          <div class="match-status match-status--warn">请先确认参与本周匹配</div>
+        </div>
+        <a href="/confirm-match" class="btn btn-small">去确认</a>
+      </div>
+      <% } %>
+    </div>
+    <% } else if (weeklyMatchConfirmed) { %>
+    <div class="card">
+      <h3 style="margin: 0 0 16px 0;">本周</h3>
+      <div class="match-card match-card--no-match">
+        <div class="match-week">第<%= currentWeekInfo.week %>周</div>
+        <div class="match-info">
+          <div class="match-status match-status--wait">已确认参与匹配，请等待周二 19:00 公布结果</div>
+        </div>
+      </div>
+    </div>
+    <% } %>
+
+    <% if (historyList && historyList.length > 0) { %>
+    <div class="card" style="margin-top: 16px;">
+      <h3 style="margin: 0 0 16px 0; color: var(--muted-foreground);">历史匹配</h3>
+      <div class="match-list">
+        <% historyList.forEach(function(m) { %>
+        <a href="/matches/detail/<%= m.matchId %>" class="match-card" style="text-decoration: none; color: inherit;">
+          <div class="match-week">第<%= m.weekNumber %>周</div>
+          <div class="match-info">
+            <div class="match-partner"><%= m.partner.nickname || m.partner.email %></div>
+            <% if (m.score !== null && m.score !== undefined) { %>
+            <% const scoreTone = m.score >= 70 ? 'high' : (m.score >= 50 ? 'medium' : 'low'); %>
+            <div class="match-score match-score--<%= scoreTone %>" style="display: inline-block; margin-top: 4px;">
+              <%= Math.round(m.score) %>分
+            </div>
+            <% } %>
+          </div>
+          <div style="color: var(--muted-foreground); font-size: 0.85rem;">查看详情 →</div>
+        </a>
+        <% }); %>
+      </div>
+    </div>
+    <% } %>
+
+    <% if ((!historyList || historyList.length === 0) && !currentWeekEntry) { %>
     <div class="card" style="text-align: center;">
       <div style="font-size: 4rem; margin-bottom: 16px;">🔍</div>
       <h2>暂无匹配记录</h2>
       <p style="color: var(--muted-foreground);">还没有匹配记录，完成问卷并确认参与匹配后会在每周二公布结果。</p>
     </div>
-    <% } else { %>
-    <div class="card">
-      <h2 style="display: flex; align-items: center; gap: 10px;">
-        💕 匹配历史
-      </h2>
-      <p style="color: var(--muted-foreground); margin-bottom: 24px;">
-        以下是你参与的所有匹配记录：
-      </p>
+    <% } %>
 
-      <div class="match-list">
-        <% matchList.forEach(function(m) { %>
-        <a href="/matches/detail/<%= m.matchId %>" class="match-card" style="text-decoration: none; color: inherit; display: flex; align-items: center; gap: 16px;">
-          <div class="match-rank">
-            <%= m.year %>
-          </div>
-          <div style="flex: 1;">
-            <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 6px;">
-              <span class="week-badge <%= (typeof currentWeekInfo !== 'undefined' && currentWeekInfo.year === m.year && currentWeekInfo.week === m.weekNumber) ? 'week-badge--current' : '' %>">
-                <%= m.year %>年第<%= m.weekNumber %>周
-              </span>
-              <span style="color: var(--muted-foreground); font-size: 0.85rem;">
-                <%= m.partner.nickname || m.partner.email %>
-              </span>
-            </div>
-          </div>
-          <% if (m.score !== null && m.score !== undefined) { %>
-          <% const scoreTone = m.score >= 70 ? 'high' : (m.score >= 50 ? 'medium' : 'low'); %>
-          <div class="match-score match-score--<%= scoreTone %>">
-            <%= Math.round(m.score) %>分
-          </div>
-          <% } %>
-        </a>
-        <% }); %>
-      </div>
-    </div>
     <% } %>
   </div>
 

--- a/views/matches.ejs
+++ b/views/matches.ejs
@@ -97,14 +97,16 @@
       <p style="color: var(--muted-foreground);">需要完成问卷才能查看匹配结果。</p>
       <a href="/profile" class="btn" style="margin-top: 16px;">去填写问卷</a>
     </div>
-    <% } else if (!weeklyMatchConfirmed) { %>
+    <% } else { %>
+
+    <% if (!weeklyMatchConfirmed) { %>
     <div class="card" style="text-align: center;">
       <div style="font-size: 4rem; margin-bottom: 16px;">🤝</div>
       <h2>请确认参与本周匹配</h2>
-      <p style="color: var(--muted-foreground); margin-bottom: 24px;">确认后即可查看历史匹配记录和参与本周匹配。</p>
+      <p style="color: var(--muted-foreground); margin-bottom: 24px;">确认后即可参与本周匹配。</p>
       <a href="/confirm-match" class="btn btn-large">确认参与匹配</a>
     </div>
-    <% } else { %>
+    <% } %>
 
     <% if (currentWeekEntry) { %>
     <div class="card">
@@ -125,7 +127,7 @@
         </div>
         <div style="color: var(--muted-foreground); font-size: 0.85rem;">查看详情 →</div>
       </a>
-      <% } else if (currentWeekEntry.status === 'no_match') { %>
+      <% } else if (currentWeekEntry.status === 'waiting') { %>
       <div class="match-card match-card--no-match">
         <div class="match-week">第<%= currentWeekEntry.weekNumber %>周</div>
         <div class="match-info">

--- a/views/matches.ejs
+++ b/views/matches.ejs
@@ -64,6 +64,20 @@
       font-size: 0.9rem;
       padding: 20px;
     }
+    .week-badge {
+      display: inline-block;
+      padding: 3px 10px;
+      border-radius: 999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      background: var(--primary);
+      color: #fff;
+      opacity: 0.85;
+    }
+    .week-badge--current {
+      background: var(--success);
+      opacity: 1;
+    }
     @media (max-width: 700px) {
       .match-card {
         flex-direction: column;
@@ -101,47 +115,60 @@
       <h2>每周匹配暂未开启</h2>
       <p style="color: var(--muted-foreground);">该功能正在调试中，开放时间请留意通知。</p>
     </div>
-    <% } else if (!matches || matches.length === 0) { %>
+    <% } else if (!hasProfile) { %>
     <div class="card" style="text-align: center;">
-      <div style="font-size: 4rem; margin-bottom: 16px;">🤔</div>
-      <h2><%= hasWeeklyRelease ? '本周暂未匹配成功' : '本周匹配尚未发布' %></h2>
-      <p style="color: var(--muted-foreground); margin-bottom: 24px;">
-        <%= hasWeeklyRelease
-          ? '本周正式匹配结果已经发布，但这周暂时还没有匹配到适合你的对象。'
-          : '匹配结果还没发布，等管理员执行本周匹配后再来看看。' %>
-      </p>
+      <div style="font-size: 4rem; margin-bottom: 16px;">📋</div>
+      <h2>请先填写问卷</h2>
+      <p style="color: var(--muted-foreground);">需要完成问卷才能查看匹配结果。</p>
+      <a href="/profile" class="btn" style="margin-top: 16px;">去填写问卷</a>
+    </div>
+    <% } else if (!weeklyMatchConfirmed) { %>
+    <div class="card" style="text-align: center;">
+      <div style="font-size: 4rem; margin-bottom: 16px;">🤝</div>
+      <h2>请确认参与本周匹配</h2>
+      <p style="color: var(--muted-foreground); margin-bottom: 24px;">确认后即可查看历史匹配记录和参与本周匹配。</p>
+      <a href="/confirm-match" class="btn btn-large">确认参与匹配</a>
+    </div>
+    <% } else if (!matchList || matchList.length === 0) { %>
+    <div class="card" style="text-align: center;">
+      <div style="font-size: 4rem; margin-bottom: 16px;">🔍</div>
+      <h2>暂无匹配记录</h2>
+      <p style="color: var(--muted-foreground);">还没有匹配记录，完成问卷并确认参与匹配后会在每周二公布结果。</p>
     </div>
     <% } else { %>
     <div class="card">
       <h2 style="display: flex; align-items: center; gap: 10px;">
-        💕 匹配结果
+        💕 匹配历史
       </h2>
       <p style="color: var(--muted-foreground); margin-bottom: 24px;">
-        这是本周已经发布并落库的正式匹配结果：
+        以下是你参与的所有匹配记录：
       </p>
 
       <div class="match-list">
-        <% matches.forEach(function(m, index) { %>
-        <a href="/matches/detail/<%= matchId %>" class="match-card" style="text-decoration: none; color: inherit; display: flex; align-items: center; gap: 16px;">
+        <% matchList.forEach(function(m) { %>
+        <a href="/matches/detail/<%= m.matchId %>" class="match-card" style="text-decoration: none; color: inherit; display: flex; align-items: center; gap: 16px;">
           <div class="match-rank">
-            #<%= index + 1 %>
+            <%= m.year %>
           </div>
           <div style="flex: 1;">
-            <div>你的匹配对象是： <%= m.nickname || m.email %> </div>
+            <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 6px;">
+              <span class="week-badge <%= (typeof currentWeekInfo !== 'undefined' && currentWeekInfo.year === m.year && currentWeekInfo.week === m.weekNumber) ? 'week-badge--current' : '' %>">
+                <%= m.year %>年第<%= m.weekNumber %>周
+              </span>
+              <span style="color: var(--muted-foreground); font-size: 0.85rem;">
+                <%= m.partner.nickname || m.partner.email %>
+              </span>
+            </div>
           </div>
+          <% if (m.score !== null && m.score !== undefined) { %>
           <% const scoreTone = m.score >= 70 ? 'high' : (m.score >= 50 ? 'medium' : 'low'); %>
           <div class="match-score match-score--<%= scoreTone %>">
             <%= Math.round(m.score) %>分
           </div>
+          <% } %>
         </a>
         <% }); %>
       </div>
-
-      <% if (matches.some(function(m) { return m.score !== null && m.score !== undefined; })) { %>
-      <p style="margin-top: 24px; color: var(--muted-foreground); font-size: 0.85rem; text-align: center;">
-        💡 匹配度算法：综合考虑兴趣爱好、生活习惯和恋爱观念，并结合 LoveType 兼容性做加减分
-      </p>
-      <% } %>
     </div>
     <% } %>
   </div>
@@ -150,32 +177,6 @@
 
   <% if (typeof isDev !== 'undefined' && isDev) { %>
   <%- include('partials/dev-tools') %>
-  <% } %>
-
-  <% if (typeof matchId !== 'undefined' && matchId && !(typeof weeklyMatch !== 'undefined' && weeklyMatch && weeklyMatch.matchComment)) { %>
-  <script>
-    (function() {
-      const commentEl = document.getElementById('match-comment');
-      const matchId = commentEl?.dataset.matchId;
-      if (!matchId) return;
-
-      fetch('/api/weekly-match/comment/' + matchId)
-        .then(function(res) { return res.json(); })
-        .then(function(data) {
-          if (data.success && data.comment) {
-            var p = document.createElement('p');
-            p.style.whiteSpace = 'pre-line';
-            p.textContent = data.comment;
-            commentEl.appendChild(p);
-          } else {
-            commentEl.textContent = '暂无可用评语';
-          }
-        })
-        .catch(function() {
-          commentEl.textContent = '加载失败';
-        });
-    })();
-  </script>
   <% } %>
 </body>
 </html>

--- a/views/matches.ejs
+++ b/views/matches.ejs
@@ -129,8 +129,7 @@
       <div class="match-card match-card--no-match">
         <div class="match-week">第<%= currentWeekEntry.weekNumber %>周</div>
         <div class="match-info">
-          <div class="match-partner" style="color: var(--muted-foreground);">抱歉，未能匹配到合适的对象</div>
-          <div class="match-status">下周再来试试吧~</div>
+          <div class="match-status match-status--wait">已确认参与匹配，请等待周二 19:00 公布结果</div>
         </div>
       </div>
       <% } else if (currentWeekEntry.status === 'not_confirmed') { %>

--- a/weekNumber.js
+++ b/weekNumber.js
@@ -1,6 +1,10 @@
+// 上海时区偏移 +8h
+const SHANGHAI_TZ = 8 * 60 * 60 * 1000;
+
 function getWeekNumber(date = new Date()) {
-  const start = new Date(date.getFullYear(), 0, 1);
-  const diff = date - start;
+  const d = new Date(date.getTime());
+  const start = new Date(d.getFullYear(), 0, 1);
+  const diff = d - start;
   return Math.floor(diff / 604800000);
 }
 
@@ -8,7 +12,28 @@ function getYear(date = new Date()) {
   return date.getFullYear();
 }
 
+function getCurrentWeekByTuesday19(date = new Date()) {
+  const nowInShanghai = new Date(date.getTime() + SHANGHAI_TZ);
+  const dayOfWeek = nowInShanghai.getDay();
+  const hours = nowInShanghai.getHours();
+  const minutes = nowInShanghai.getMinutes();
+
+  const isPastTuesday19 = dayOfWeek > 2 || (dayOfWeek === 2 && (hours > 19 || (hours === 19 && minutes >= 0)));
+
+  const d = new Date(date.getTime());
+  if (isPastTuesday19) {
+    d.setDate(d.getDate() + 7);
+  }
+  const start = new Date(d.getFullYear(), 0, 1);
+  const diff = d - start;
+  return {
+    year: d.getFullYear(),
+    week: Math.floor(diff / 604800000)
+  };
+}
+
 module.exports = {
   getWeekNumber,
-  getYear
+  getYear,
+  getCurrentWeekByTuesday19
 };


### PR DESCRIPTION
- 新增 getCurrentWeekByTuesday19 函数，以上海时间周二19:00为周分界
- 主页统一显示"距离下周二19:00"倒计时，移除"本周匹配已开启"状态
- 用户确认、匹配查询等场景均使用新的周边界逻辑
