### PR TITLE
feat: 注册页面添加邮箱申请指引

### DIFF
--- a/public/css/account-pages.css
+++ b/public/css/account-pages.css
@@ -142,6 +142,46 @@
   margin-bottom: 16px;
 }
 
+.email-with-help {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.email-help-link {
+  font-size: 0.8rem;
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.email-help-link:hover {
+  text-decoration: underline;
+}
+
+.email-guide {
+  margin-bottom: 16px;
+  padding: 16px;
+  background: var(--surface-soft);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+
+.email-guide-content p {
+  margin: 0 0 12px;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.email-guide-content p:last-child {
+  margin-bottom: 0;
+}
+
+.email-guide-content a {
+  color: var(--primary);
+  word-break: break-all;
+}
+
 .form-group--final {
   margin-bottom: 20px;
 }

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -60,8 +60,16 @@
         <div class="form-group">
           <input class="form-control-center" type="text" name="nickname" placeholder="昵称" value="<%= typeof nickname !== 'undefined' ? nickname : '' %>" autocomplete="nickname" aria-label="昵称" required>
         </div>
-        <div class="form-group">
+        <div class="form-group email-with-help">
           <input class="form-control-center" type="email" name="email" placeholder="学校邮箱 (@shu.edu.cn)" value="<%= typeof email !== 'undefined' ? email : '' %>" autocomplete="email" aria-label="学校邮箱" autocapitalize="none" autocorrect="off" inputmode="email" required>
+          <a href="javascript:void(0)" class="email-help-link" onclick="toggleEmailGuide()">邮箱申请指引</a>
+        </div>
+        <div id="email-guide" class="email-guide" style="display: none;">
+          <div class="email-guide-content">
+            <p><strong>邮箱账号申请：</strong><a href="https://oauth.shu.edu.cn/" target="_blank">https://oauth.shu.edu.cn/</a></p>
+            <p><strong>申请完成后登录上海大学邮件系统：</strong><a href="https://newmail.shu.edu.cn/coremail/" target="_blank">https://newmail.shu.edu.cn/coremail/</a></p>
+            <p><strong>忘记邮箱账号：</strong>点击忘记密码 -&gt; 邮箱申请 -&gt; 随便写一个邮箱账号 -&gt; 点击确认就可以弹出之前注册的邮箱账号</p>
+          </div>
         </div>
         <div class="form-group">
           <input class="form-control-center" type="password" name="password" placeholder="设置密码（至少6位）" autocomplete="new-password" aria-label="设置密码" required minlength="6">
@@ -92,5 +100,15 @@
   </div>
 
   <%- include('partials/site-footer') %>
+<script>
+function toggleEmailGuide() {
+  var guide = document.getElementById('email-guide');
+  if (guide.style.display === 'none') {
+    guide.style.display = 'block';
+  } else {
+    guide.style.display = 'none';
+  }
+}
+</script>
 </body>
 </html>


### PR DESCRIPTION
在注册表单的邮箱输入框下方添加"邮箱申请指引"链接，点击可展开显示：
- 邮箱账号申请地址
- 上海大学邮件系统登录地址
- 忘记账号的找回方法
