### PR TITLE
[codex] 修复每周确认状态重复失效

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,6 @@ jobs:
 
       - name: Check matchService.js syntax
         run: node --check matchService.js
+
+      - name: Run tests
+        run: npm test

--- a/app.js
+++ b/app.js
@@ -7,7 +7,7 @@ const bcrypt = require('bcryptjs');
 const fs = require('fs');
 const path = require('path');
 const packageJson = require('./package.json');
-const { getWeekNumber, getYear, getCurrentWeekByTuesday19 } = require('./weekNumber');
+const { getWeekNumber, getYear, getCurrentWeekByTuesday19, getLastClosedWeekByTuesday19 } = require('./weekNumber');
 require('dotenv').config();
 const lovetypeService = require('./lovetypeService');
 const dbModule = require('./database');
@@ -2605,7 +2605,8 @@ app.post('/api/cron/weekly-match', requireValidCronSecret, cronRateLimiter, wrap
 
 async function runWeeklyMatch() {
   const matchService = require('./matchService');
-  const result = await matchService.saveWeeklyMatches();
+  const weekInfo = getLastClosedWeekByTuesday19();
+  const result = await matchService.saveWeeklyMatches(weekInfo.year, weekInfo.week);
 
   if (!result.success) {
     return result;

--- a/app.js
+++ b/app.js
@@ -11,11 +11,10 @@ const {
   getWeekNumber,
   getYear,
   getCurrentWeekByTuesday19,
-  getLastClosedWeekByTuesday19,
-  getCompatibleWeekKeysForWeek,
-  getCompatibleCurrentWeekKeysByTuesday19,
-  getCompatibleLastClosedWeekKeysByTuesday19,
-  isWeekKeyIncluded
+  getCurrentConfirmationWindowByTuesday19,
+  getLastClosedConfirmationWindowByTuesday19,
+  getConfirmationWindowForWeek,
+  isConfirmationIncludedInWindow
 } = require('./weekNumber');
 require('dotenv').config();
 const lovetypeService = require('./lovetypeService');
@@ -371,7 +370,7 @@ async function loadCurrentUserFromSession(req) {
   }
 
   const currentUser = await db.queryOne(`
-    SELECT id, email, nickname, name, verified, weekly_match_year, weekly_match_week
+    SELECT id, email, nickname, name, verified, weekly_match_year, weekly_match_week, weekly_match_confirmed_at
     FROM users
     WHERE id = $1
   `, [req.session.userId]);
@@ -388,10 +387,14 @@ async function loadCurrentUserFromSession(req) {
     [currentUser.id]
   );
 
-  // 检查是否确认了本周的匹配（year + week 与当前周一致）
-  const currentWeekKeys = getCompatibleCurrentWeekKeysByTuesday19();
-  const weeklyMatchConfirmed = currentUser.weekly_match_year != null
-    && isWeekKeyIncluded(currentWeekKeys, currentUser.weekly_match_year, currentUser.weekly_match_week);
+  // 检查是否确认了本周的匹配（year + week + 窗口时间）
+  const currentConfirmationWindow = getCurrentConfirmationWindowByTuesday19();
+  const weeklyMatchConfirmed = isConfirmationIncludedInWindow(
+    currentConfirmationWindow,
+    currentUser.weekly_match_year,
+    currentUser.weekly_match_week,
+    currentUser.weekly_match_confirmed_at
+  );
 
   const user = {
     id: currentUser.id,
@@ -1613,7 +1616,7 @@ app.post('/confirm-match', isLoggedIn, requireValidCsrf, wrapAsync(async (req, r
   // 更新确认状态为当前 year + week
   const currentWeekInfo = getCurrentWeekByTuesday19();
   await db.execute(
-    'UPDATE users SET weekly_match_year = $1, weekly_match_week = $2 WHERE id = $3',
+    'UPDATE users SET weekly_match_year = $1, weekly_match_week = $2, weekly_match_confirmed_at = CURRENT_TIMESTAMP WHERE id = $3',
     [currentWeekInfo.year, currentWeekInfo.week, req.user.id]
   );
 
@@ -1624,7 +1627,7 @@ app.post('/confirm-match', isLoggedIn, requireValidCsrf, wrapAsync(async (req, r
 app.post('/confirm-match/cancel', isLoggedIn, requireValidCsrf, wrapAsync(async (req, res) => {
   // 将 year 和 week 设为 0，表示取消
   await db.execute(
-    'UPDATE users SET weekly_match_year = 0, weekly_match_week = 0 WHERE id = $1',
+    'UPDATE users SET weekly_match_year = 0, weekly_match_week = 0, weekly_match_confirmed_at = NULL WHERE id = $1',
     [req.user.id]
   );
 
@@ -2326,9 +2329,10 @@ app.get('/api/matches', isLoggedIn, wrapAsync(async (req, res) => {
   }
   const matchService = require('./matchService');
   const matchDate = new Date();
-  const weekInfo = getCurrentWeekByTuesday19(matchDate);
+  const confirmationWindow = getCurrentConfirmationWindowByTuesday19(matchDate);
+  const weekInfo = confirmationWindow.canonicalWeek;
   const matches = await matchService.findMatches(req.user.id, weekInfo.year, weekInfo.week, {
-    confirmationWeekKeys: getCompatibleCurrentWeekKeysByTuesday19(matchDate)
+    confirmationWindow
   });
   res.json({ success: true, source: 'recommendation', data: matches });
 }));
@@ -2341,9 +2345,10 @@ app.get('/api/match/top', isLoggedIn, wrapAsync(async (req, res) => {
   }
   const matchService = require('./matchService');
   const matchDate = new Date();
-  const weekInfo = getCurrentWeekByTuesday19(matchDate);
+  const confirmationWindow = getCurrentConfirmationWindowByTuesday19(matchDate);
+  const weekInfo = confirmationWindow.canonicalWeek;
   const matches = await matchService.getTopMatches(req.user.id, 5, weekInfo.year, weekInfo.week, {
-    confirmationWeekKeys: getCompatibleCurrentWeekKeysByTuesday19(matchDate)
+    confirmationWindow
   });
   res.json({ success: true, source: 'recommendation', data: matches });
 }));
@@ -2455,7 +2460,7 @@ app.get('/admin', isLoggedIn, requireAdmin, wrapAsync(async (req, res) => {
   `);
 
   const adminWeekDate = new Date();
-  const weekInfo = getLastClosedWeekByTuesday19(adminWeekDate);
+  const weekInfo = getLastClosedConfirmationWindowByTuesday19(adminWeekDate).canonicalWeek;
   res.render('admin', {
     title: '管理',
     user: req.user,
@@ -2626,9 +2631,10 @@ async function runWeeklyMatch() {
 async function runClosedWeeklyMatch() {
   const matchService = require('./matchService');
   const matchDate = new Date();
-  const weekInfo = getLastClosedWeekByTuesday19(matchDate);
+  const confirmationWindow = getLastClosedConfirmationWindowByTuesday19(matchDate);
+  const weekInfo = confirmationWindow.canonicalWeek;
   const result = await matchService.saveWeeklyMatches(weekInfo.year, weekInfo.week, {
-    confirmationWeekKeys: getCompatibleLastClosedWeekKeysByTuesday19(matchDate)
+    confirmationWindow
   });
 
   if (!result.success) {
@@ -2670,8 +2676,9 @@ async function runClosedWeeklyMatch() {
  */
 async function runWeeklyMatchWithWeek(targetYear, targetWeek) {
   const matchService = require('./matchService');
+  const confirmationWindow = getConfirmationWindowForWeek(targetYear, targetWeek);
   const result = await matchService.saveWeeklyMatches(targetYear, targetWeek, {
-    confirmationWeekKeys: getCompatibleWeekKeysForWeek(targetYear, targetWeek)
+    confirmationWindow
   });
 
   if (!result.success) {

--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@ const {
   getYear,
   getCurrentWeekByTuesday19,
   getLastClosedWeekByTuesday19,
+  getCompatibleWeekKeysForWeek,
   getCompatibleCurrentWeekKeysByTuesday19,
   getCompatibleLastClosedWeekKeysByTuesday19,
   isWeekKeyIncluded
@@ -2324,9 +2325,10 @@ app.get('/api/matches', isLoggedIn, wrapAsync(async (req, res) => {
     return res.status(403).json({ success: false, error: '请先确认参与本周匹配' });
   }
   const matchService = require('./matchService');
-  const weekInfo = getCurrentWeekByTuesday19();
+  const matchDate = new Date();
+  const weekInfo = getCurrentWeekByTuesday19(matchDate);
   const matches = await matchService.findMatches(req.user.id, weekInfo.year, weekInfo.week, {
-    confirmationWeekKeys: getCompatibleCurrentWeekKeysByTuesday19()
+    confirmationWeekKeys: getCompatibleCurrentWeekKeysByTuesday19(matchDate)
   });
   res.json({ success: true, source: 'recommendation', data: matches });
 }));
@@ -2338,9 +2340,10 @@ app.get('/api/match/top', isLoggedIn, wrapAsync(async (req, res) => {
     return res.status(403).json({ success: false, error: '请先确认参与本周匹配' });
   }
   const matchService = require('./matchService');
-  const weekInfo = getCurrentWeekByTuesday19();
+  const matchDate = new Date();
+  const weekInfo = getCurrentWeekByTuesday19(matchDate);
   const matches = await matchService.getTopMatches(req.user.id, 5, weekInfo.year, weekInfo.week, {
-    confirmationWeekKeys: getCompatibleCurrentWeekKeysByTuesday19()
+    confirmationWeekKeys: getCompatibleCurrentWeekKeysByTuesday19(matchDate)
   });
   res.json({ success: true, source: 'recommendation', data: matches });
 }));
@@ -2451,7 +2454,8 @@ app.get('/admin', isLoggedIn, requireAdmin, wrapAsync(async (req, res) => {
     ORDER BY u.created_at DESC
   `);
 
-  const weekInfo = getCurrentWeekByTuesday19();
+  const adminWeekDate = new Date();
+  const weekInfo = getLastClosedWeekByTuesday19(adminWeekDate);
   res.render('admin', {
     title: '管理',
     user: req.user,
@@ -2615,49 +2619,16 @@ app.post('/api/cron/weekly-match', requireValidCronSecret, cronRateLimiter, wrap
 // ============ 匹配逻辑 ============
 
 async function runWeeklyMatch() {
-  const matchService = require('./matchService');
-  const weekInfo = getCurrentWeekByTuesday19();
-  const result = await matchService.saveWeeklyMatches(weekInfo.year, weekInfo.week, {
-    confirmationWeekKeys: getCompatibleCurrentWeekKeysByTuesday19()
-  });
-
-  if (!result.success) {
-    return result;
-  }
-
-  // TODO: 匹配邮件通知已禁用，如需启用请恢复以下代码
-  // const { sendMatchEmail } = require('./mailer');
-  // const emailTasks = [];
-  // for (const pair of result.results || []) {
-  //   emailTasks.push(sendMatchEmail(
-  //     pair.user1.email,
-  //     pair.user1.nickname || '同学',
-  //     pair.user2.nickname || 'TA',
-  //     pair.user2.my_grade,
-  //     null
-  //   ));
-  //   emailTasks.push(sendMatchEmail(
-  //     pair.user2.email,
-  //     pair.user2.nickname || '同学',
-  //     pair.user1.nickname || 'TA',
-  //     pair.user1.my_grade,
-  //     null
-  //   ));
-  // }
-  // const emailResults = await Promise.all(emailTasks);
-  // const failedEmailCount = emailResults.filter(item => !item?.success).length;
-  // if (failedEmailCount > 0) {
-  //   console.error(`❌ 本次匹配共有 ${failedEmailCount} 封邮件发送失败`);
-  // }
-
-  return result;
+  // Admin manual trigger mirrors cron so it can retry the just-closed cycle.
+  return runClosedWeeklyMatch();
 }
 
 async function runClosedWeeklyMatch() {
   const matchService = require('./matchService');
-  const weekInfo = getLastClosedWeekByTuesday19();
+  const matchDate = new Date();
+  const weekInfo = getLastClosedWeekByTuesday19(matchDate);
   const result = await matchService.saveWeeklyMatches(weekInfo.year, weekInfo.week, {
-    confirmationWeekKeys: getCompatibleLastClosedWeekKeysByTuesday19()
+    confirmationWeekKeys: getCompatibleLastClosedWeekKeysByTuesday19(matchDate)
   });
 
   if (!result.success) {
@@ -2699,7 +2670,9 @@ async function runClosedWeeklyMatch() {
  */
 async function runWeeklyMatchWithWeek(targetYear, targetWeek) {
   const matchService = require('./matchService');
-  const result = await matchService.saveWeeklyMatches(targetYear, targetWeek);
+  const result = await matchService.saveWeeklyMatches(targetYear, targetWeek, {
+    confirmationWeekKeys: getCompatibleWeekKeysForWeek(targetYear, targetWeek)
+  });
 
   if (!result.success) {
     return result;

--- a/app.js
+++ b/app.js
@@ -7,7 +7,15 @@ const bcrypt = require('bcryptjs');
 const fs = require('fs');
 const path = require('path');
 const packageJson = require('./package.json');
-const { getWeekNumber, getYear, getCurrentWeekByTuesday19, getLastClosedWeekByTuesday19 } = require('./weekNumber');
+const {
+  getWeekNumber,
+  getYear,
+  getCurrentWeekByTuesday19,
+  getLastClosedWeekByTuesday19,
+  getCompatibleCurrentWeekKeysByTuesday19,
+  getCompatibleLastClosedWeekKeysByTuesday19,
+  isWeekKeyIncluded
+} = require('./weekNumber');
 require('dotenv').config();
 const lovetypeService = require('./lovetypeService');
 const dbModule = require('./database');
@@ -380,10 +388,9 @@ async function loadCurrentUserFromSession(req) {
   );
 
   // 检查是否确认了本周的匹配（year + week 与当前周一致）
-  const currentWeekInfo = getCurrentWeekByTuesday19();
+  const currentWeekKeys = getCompatibleCurrentWeekKeysByTuesday19();
   const weeklyMatchConfirmed = currentUser.weekly_match_year != null
-    && currentUser.weekly_match_year === currentWeekInfo.year
-    && currentUser.weekly_match_week === currentWeekInfo.week;
+    && isWeekKeyIncluded(currentWeekKeys, currentUser.weekly_match_year, currentUser.weekly_match_week);
 
   const user = {
     id: currentUser.id,
@@ -2318,7 +2325,9 @@ app.get('/api/matches', isLoggedIn, wrapAsync(async (req, res) => {
   }
   const matchService = require('./matchService');
   const weekInfo = getCurrentWeekByTuesday19();
-  const matches = await matchService.findMatches(req.user.id, weekInfo.year, weekInfo.week);
+  const matches = await matchService.findMatches(req.user.id, weekInfo.year, weekInfo.week, {
+    confirmationWeekKeys: getCompatibleCurrentWeekKeysByTuesday19()
+  });
   res.json({ success: true, source: 'recommendation', data: matches });
 }));
 
@@ -2330,7 +2339,9 @@ app.get('/api/match/top', isLoggedIn, wrapAsync(async (req, res) => {
   }
   const matchService = require('./matchService');
   const weekInfo = getCurrentWeekByTuesday19();
-  const matches = await matchService.getTopMatches(req.user.id, 5, weekInfo.year, weekInfo.week);
+  const matches = await matchService.getTopMatches(req.user.id, 5, weekInfo.year, weekInfo.week, {
+    confirmationWeekKeys: getCompatibleCurrentWeekKeysByTuesday19()
+  });
   res.json({ success: true, source: 'recommendation', data: matches });
 }));
 
@@ -2564,7 +2575,7 @@ app.post('/api/cron/weekly-match', requireValidCronSecret, cronRateLimiter, wrap
   console.log(`[Cron] 开始执行周匹配: ${timestamp}`);
 
   try {
-    const result = await runWeeklyMatch();
+    const result = await runClosedWeeklyMatch();
 
     // 发送告警通知
     const { alertMatchSuccess, alertMatchSkipped } = require('./alertService');
@@ -2605,8 +2616,49 @@ app.post('/api/cron/weekly-match', requireValidCronSecret, cronRateLimiter, wrap
 
 async function runWeeklyMatch() {
   const matchService = require('./matchService');
+  const weekInfo = getCurrentWeekByTuesday19();
+  const result = await matchService.saveWeeklyMatches(weekInfo.year, weekInfo.week, {
+    confirmationWeekKeys: getCompatibleCurrentWeekKeysByTuesday19()
+  });
+
+  if (!result.success) {
+    return result;
+  }
+
+  // TODO: 匹配邮件通知已禁用，如需启用请恢复以下代码
+  // const { sendMatchEmail } = require('./mailer');
+  // const emailTasks = [];
+  // for (const pair of result.results || []) {
+  //   emailTasks.push(sendMatchEmail(
+  //     pair.user1.email,
+  //     pair.user1.nickname || '同学',
+  //     pair.user2.nickname || 'TA',
+  //     pair.user2.my_grade,
+  //     null
+  //   ));
+  //   emailTasks.push(sendMatchEmail(
+  //     pair.user2.email,
+  //     pair.user2.nickname || '同学',
+  //     pair.user1.nickname || 'TA',
+  //     pair.user1.my_grade,
+  //     null
+  //   ));
+  // }
+  // const emailResults = await Promise.all(emailTasks);
+  // const failedEmailCount = emailResults.filter(item => !item?.success).length;
+  // if (failedEmailCount > 0) {
+  //   console.error(`❌ 本次匹配共有 ${failedEmailCount} 封邮件发送失败`);
+  // }
+
+  return result;
+}
+
+async function runClosedWeeklyMatch() {
+  const matchService = require('./matchService');
   const weekInfo = getLastClosedWeekByTuesday19();
-  const result = await matchService.saveWeeklyMatches(weekInfo.year, weekInfo.week);
+  const result = await matchService.saveWeeklyMatches(weekInfo.year, weekInfo.week, {
+    confirmationWeekKeys: getCompatibleLastClosedWeekKeysByTuesday19()
+  });
 
   if (!result.success) {
     return result;

--- a/database.js
+++ b/database.js
@@ -1,4 +1,5 @@
 const { Pool } = require('pg');
+const { getCurrentConfirmationWindowByTuesday19 } = require('./weekNumber');
 const SESSION_TABLE_NAME = 'user_sessions';
 const SESSION_EXPIRE_INDEX_NAME = 'idx_user_sessions_expire';
 
@@ -41,7 +42,34 @@ async function initDatabase() {
   await pool.query('ALTER TABLE users DROP COLUMN IF EXISTS weekly_match_confirmed');
   await pool.query('ALTER TABLE users ADD COLUMN IF NOT EXISTS weekly_match_year INTEGER DEFAULT 0');
   await pool.query('ALTER TABLE users ADD COLUMN IF NOT EXISTS weekly_match_week INTEGER DEFAULT 0');
+  const confirmedAtColumn = await pool.query(`
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = current_schema()
+      AND table_name = 'users'
+      AND column_name = 'weekly_match_confirmed_at'
+  `);
   await pool.query('ALTER TABLE users ADD COLUMN IF NOT EXISTS weekly_match_confirmed_at TIMESTAMPTZ');
+  if (confirmedAtColumn.rowCount === 0) {
+    const currentWindow = getCurrentConfirmationWindowByTuesday19();
+    const weekKeys = currentWindow.weekKeys || [];
+    const params = [];
+    const keyClauses = weekKeys.map(weekInfo => {
+      params.push(weekInfo.year, weekInfo.week);
+      return `(weekly_match_year = $${params.length - 1} AND weekly_match_week = $${params.length})`;
+    });
+
+    if (keyClauses.length > 0) {
+      await pool.query(`
+        UPDATE users
+        SET weekly_match_confirmed_at = CURRENT_TIMESTAMP
+        WHERE weekly_match_confirmed_at IS NULL
+          AND weekly_match_year IS NOT NULL
+          AND weekly_match_year <> 0
+          AND (${keyClauses.join(' OR ')})
+      `, params);
+    }
+  }
   
   // profiles 表
   await pool.query(`

--- a/database.js
+++ b/database.js
@@ -41,6 +41,7 @@ async function initDatabase() {
   await pool.query('ALTER TABLE users DROP COLUMN IF EXISTS weekly_match_confirmed');
   await pool.query('ALTER TABLE users ADD COLUMN IF NOT EXISTS weekly_match_year INTEGER DEFAULT 0');
   await pool.query('ALTER TABLE users ADD COLUMN IF NOT EXISTS weekly_match_week INTEGER DEFAULT 0');
+  await pool.query('ALTER TABLE users ADD COLUMN IF NOT EXISTS weekly_match_confirmed_at TIMESTAMPTZ');
   
   // profiles 表
   await pool.query(`

--- a/matchService.js
+++ b/matchService.js
@@ -23,6 +23,31 @@ const { getWeekNumber, getYear, getCurrentWeekByTuesday19 } = require('./weekNum
 
 // ============ 工具函数 ============
 
+function normalizeConfirmationWeekKeys(targetYear, targetWeek, options = {}) {
+  const weekKeys = Array.isArray(options.confirmationWeekKeys) && options.confirmationWeekKeys.length > 0
+    ? options.confirmationWeekKeys
+    : [{ year: targetYear, week: targetWeek }];
+  const unique = new Map();
+
+  weekKeys.forEach(weekInfo => {
+    const year = parseNullableInt(weekInfo?.year);
+    const week = parseNullableInt(weekInfo?.week);
+    if (year === null || week === null) return;
+    unique.set(`${year}-${week}`, { year, week });
+  });
+
+  return Array.from(unique.values());
+}
+
+function addConfirmationWeekFilters(filters, params, weekKeys) {
+  const keyClauses = weekKeys.map(weekInfo => {
+    params.push(weekInfo.year, weekInfo.week);
+    return `(u.weekly_match_year = $${params.length - 1} AND u.weekly_match_week = $${params.length})`;
+  });
+
+  filters.push(keyClauses.length > 0 ? `(${keyClauses.join(' OR ')})` : 'FALSE');
+}
+
 function parseNullableInt(value) {
   if (value === null || value === undefined || value === '') return null;
   const parsed = parseInt(value, 10);
@@ -311,7 +336,7 @@ function calculateMatchDetails(myProfile, theirProfile) {
 
 // ============ 数据库查询接口 ============
 
-async function findMatches(userId, targetYear = null, targetWeek = null) {
+async function findMatches(userId, targetYear = null, targetWeek = null, options = {}) {
   const userIdInt = parseInt(userId, 10);
   const myUser = await dbModule.queryOne('SELECT * FROM users WHERE id = $1', [userIdInt]);
   if (!myUser) return [];
@@ -323,9 +348,8 @@ async function findMatches(userId, targetYear = null, targetWeek = null) {
   const params = [userIdInt];
 
   if (targetYear !== null && targetWeek !== null) {
-    params.push(targetYear, targetWeek);
-    filters.push(`u.weekly_match_year = $${params.length - 1}`);
-    filters.push(`u.weekly_match_week = $${params.length}`);
+    const weekKeys = normalizeConfirmationWeekKeys(targetYear, targetWeek, options);
+    addConfirmationWeekFilters(filters, params, weekKeys);
   }
 
   const allProfiles = await dbModule.query(`
@@ -374,26 +398,28 @@ async function findMatches(userId, targetYear = null, targetWeek = null) {
   return scored;
 }
 
-async function getTopMatches(userId, topN = 5, targetYear = null, targetWeek = null) {
-  const matches = await findMatches(userId, targetYear, targetWeek);
+async function getTopMatches(userId, topN = 5, targetYear = null, targetWeek = null, options = {}) {
+  const matches = await findMatches(userId, targetYear, targetWeek, options);
   return matches.slice(0, topN);
 }
 
-async function saveWeeklyMatches(targetYear = null, targetWeek = null) {
+async function saveWeeklyMatches(targetYear = null, targetWeek = null, options = {}) {
   const weekInfo = targetYear !== null && targetWeek !== null
     ? { year: targetYear, week: targetWeek }
     : getCurrentWeekByTuesday19();
   const year = weekInfo.year;
   const weekNumber = weekInfo.week;
+  const confirmationWeekKeys = normalizeConfirmationWeekKeys(year, weekNumber, options);
+  const userFilters = ['u.verified = 1'];
+  const userParams = [];
+  addConfirmationWeekFilters(userFilters, userParams, confirmationWeekKeys);
 
   const users = await dbModule.query(`
     SELECT u.id as user_id, u.email, u.nickname, u.name, p.my_grade
     FROM users u
     JOIN profiles p ON u.id = p.user_id
-    WHERE u.verified = 1
-      AND u.weekly_match_year = $1
-      AND u.weekly_match_week = $2
-  `, [year, weekNumber]);
+    WHERE ${userFilters.join(' AND ')}
+  `, userParams);
 
   if (users.length < 2) {
     return { success: false, message: '用户数量不足' };
@@ -405,7 +431,7 @@ async function saveWeeklyMatches(targetYear = null, targetWeek = null) {
   for (const user of users) {
     if (matched.has(user.user_id)) continue;
 
-    const allMatches = await findMatches(user.user_id, year, weekNumber);
+    const allMatches = await findMatches(user.user_id, year, weekNumber, { confirmationWeekKeys });
     const matches = allMatches.filter(m => !matched.has(m.user_id));
 
     if (matches.length > 0) {

--- a/matchService.js
+++ b/matchService.js
@@ -476,11 +476,12 @@ async function saveWeeklyMatches(targetYear = null, targetWeek = null, options =
 
   const matched = new Set();
   const results = [];
+  const candidateOptions = confirmationWindow ? { confirmationWindow } : { confirmationWeekKeys };
 
   for (const user of users) {
     if (matched.has(user.user_id)) continue;
 
-    const allMatches = await findMatches(user.user_id, year, weekNumber, { confirmationWeekKeys });
+    const allMatches = await findMatches(user.user_id, year, weekNumber, candidateOptions);
     const matches = allMatches.filter(m => !matched.has(m.user_id));
 
     if (matches.length > 0) {

--- a/matchService.js
+++ b/matchService.js
@@ -19,14 +19,11 @@
 
 const dbModule = require('./database');
 const lovetypeService = require('./lovetypeService');
-const { getWeekNumber, getYear, getCurrentWeekByTuesday19 } = require('./weekNumber');
+const { getCurrentConfirmationWindowByTuesday19 } = require('./weekNumber');
 
 // ============ 工具函数 ============
 
-function normalizeConfirmationWeekKeys(targetYear, targetWeek, options = {}) {
-  const weekKeys = Array.isArray(options.confirmationWeekKeys) && options.confirmationWeekKeys.length > 0
-    ? options.confirmationWeekKeys
-    : [{ year: targetYear, week: targetWeek }];
+function normalizeWeekKeyList(weekKeys) {
   const unique = new Map();
 
   weekKeys.forEach(weekInfo => {
@@ -39,13 +36,55 @@ function normalizeConfirmationWeekKeys(targetYear, targetWeek, options = {}) {
   return Array.from(unique.values());
 }
 
-function addConfirmationWeekFilters(filters, params, weekKeys) {
-  const keyClauses = weekKeys.map(weekInfo => {
-    params.push(weekInfo.year, weekInfo.week);
-    return `(u.weekly_match_year = $${params.length - 1} AND u.weekly_match_week = $${params.length})`;
-  });
+function normalizeConfirmationWeekKeys(targetYear, targetWeek, options = {}) {
+  const weekKeys = Array.isArray(options.confirmationWeekKeys) && options.confirmationWeekKeys.length > 0
+    ? options.confirmationWeekKeys
+    : [{ year: targetYear, week: targetWeek }];
 
+  return normalizeWeekKeyList(weekKeys);
+}
+
+function addWeekKeyClause(params, weekInfo) {
+  params.push(weekInfo.year, weekInfo.week);
+  return `(u.weekly_match_year = $${params.length - 1} AND u.weekly_match_week = $${params.length})`;
+}
+
+function addConfirmationWeekFilters(filters, params, weekKeys) {
+  const keyClauses = weekKeys.map(weekInfo => addWeekKeyClause(params, weekInfo));
   filters.push(keyClauses.length > 0 ? `(${keyClauses.join(' OR ')})` : 'FALSE');
+}
+
+function addConfirmationWindowFilters(filters, params, confirmationWindow) {
+  const canonicalWeek = confirmationWindow?.canonicalWeek;
+  const startAt = confirmationWindow?.startAt;
+  const endAt = confirmationWindow?.endAt;
+
+  if (!canonicalWeek || !startAt || !endAt) {
+    const fallbackKeys = canonicalWeek ? [canonicalWeek] : [];
+    addConfirmationWeekFilters(filters, params, fallbackKeys);
+    return;
+  }
+
+  const clauses = [];
+  const canonicalClause = addWeekKeyClause(params, canonicalWeek);
+  params.push(startAt, endAt);
+  clauses.push(
+    `(${canonicalClause} AND u.weekly_match_confirmed_at >= $${params.length - 1} AND u.weekly_match_confirmed_at < $${params.length})`
+  );
+
+  const legacyWeekKeys = normalizeWeekKeyList(confirmationWindow.legacyWeekKeys || []);
+  if (legacyWeekKeys.length > 0) {
+    const legacyKeyClauses = legacyWeekKeys.map(weekInfo => addWeekKeyClause(params, weekInfo));
+    params.push(startAt, endAt);
+    clauses.push(
+      `((${legacyKeyClauses.join(' OR ')}) AND (` +
+      `u.weekly_match_confirmed_at IS NULL OR ` +
+      `(u.weekly_match_confirmed_at >= $${params.length - 1} AND u.weekly_match_confirmed_at < $${params.length})` +
+      `))`
+    );
+  }
+
+  filters.push(`(${clauses.join(' OR ')})`);
 }
 
 function parseNullableInt(value) {
@@ -347,7 +386,9 @@ async function findMatches(userId, targetYear = null, targetWeek = null, options
   const filters = ['u.id != $1', 'u.verified = 1'];
   const params = [userIdInt];
 
-  if (targetYear !== null && targetWeek !== null) {
+  if (options.confirmationWindow) {
+    addConfirmationWindowFilters(filters, params, options.confirmationWindow);
+  } else if (targetYear !== null && targetWeek !== null) {
     const weekKeys = normalizeConfirmationWeekKeys(targetYear, targetWeek, options);
     addConfirmationWeekFilters(filters, params, weekKeys);
   }
@@ -404,15 +445,23 @@ async function getTopMatches(userId, topN = 5, targetYear = null, targetWeek = n
 }
 
 async function saveWeeklyMatches(targetYear = null, targetWeek = null, options = {}) {
+  const confirmationWindow = options.confirmationWindow || (targetYear === null || targetWeek === null
+    ? getCurrentConfirmationWindowByTuesday19()
+    : null);
   const weekInfo = targetYear !== null && targetWeek !== null
     ? { year: targetYear, week: targetWeek }
-    : getCurrentWeekByTuesday19();
+    : confirmationWindow.canonicalWeek;
   const year = weekInfo.year;
   const weekNumber = weekInfo.week;
   const confirmationWeekKeys = normalizeConfirmationWeekKeys(year, weekNumber, options);
   const userFilters = ['u.verified = 1'];
   const userParams = [];
-  addConfirmationWeekFilters(userFilters, userParams, confirmationWeekKeys);
+
+  if (confirmationWindow) {
+    addConfirmationWindowFilters(userFilters, userParams, confirmationWindow);
+  } else {
+    addConfirmationWeekFilters(userFilters, userParams, confirmationWeekKeys);
+  }
 
   const users = await dbModule.query(`
     SELECT u.id as user_id, u.email, u.nickname, u.name, p.my_grade

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "node app.js",
     "dev": "node app.js",
+    "test": "node --test weekNumber.test.js",
     "build": "node build.js",
     "build:reset": "node build.js --reset"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "node app.js",
     "dev": "node app.js",
-    "test": "node --test weekNumber.test.js",
+    "test": "node --test",
     "build": "node build.js",
     "build:reset": "node build.js --reset"
   },

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -25,7 +25,7 @@
           </div>
           <button type="submit" class="btn">🔄 执行匹配</button>
         </form>
-        <span style="margin-left: 15px; color: var(--muted-foreground); font-size: 12px;">将执行第 <%= weekNumber %> 周</span>
+        <span style="margin-left: 15px; color: var(--muted-foreground); font-size: 12px;">将执行 <%= year %> 年第 <%= weekNumber %> 周</span>
       </div>
 
       <div style="margin-bottom: 20px; padding: 15px; background: var(--surface-soft); border-radius: 8px; border-left: 4px solid var(--warning);">

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -15,7 +15,7 @@
       <h2>👥 用户管理</h2>
 
       <div style="margin-bottom: 20px; padding: 15px; background: var(--info-bg); border-radius: 8px; border-left: 4px solid var(--info);">
-        <h4 style="margin: 0 0 10px 0; color: var(--info-foreground);">🔄 手动触发本周匹配</h4>
+        <h4 style="margin: 0 0 10px 0; color: var(--info-foreground);">🔄 手动触发已截止匹配</h4>
         <form action="/admin/match" method="POST" style="display: flex; gap: 10px; align-items: center; flex-wrap: wrap;">
           <input type="hidden" name="csrfToken" value="<%= csrfToken %>">
           <div>
@@ -25,7 +25,7 @@
           </div>
           <button type="submit" class="btn">🔄 执行匹配</button>
         </form>
-        <span style="margin-left: 15px; color: var(--muted-foreground); font-size: 12px;">当前第 <%= weekNumber %> 周</span>
+        <span style="margin-left: 15px; color: var(--muted-foreground); font-size: 12px;">将执行第 <%= weekNumber %> 周</span>
       </div>
 
       <div style="margin-bottom: 20px; padding: 15px; background: var(--surface-soft); border-radius: 8px; border-left: 4px solid var(--warning);">

--- a/weekNumber.js
+++ b/weekNumber.js
@@ -44,29 +44,109 @@ function getThisWeekTuesday19LocalMs(localMs) {
   );
 }
 
-function getCurrentWeekByTuesday19(date = new Date()) {
+function getCurrentWeekWindowLocalMs(date = new Date()) {
   const localMs = getShanghaiLocalMs(date);
   const thisTuesday19LocalMs = getThisWeekTuesday19LocalMs(localMs);
-  const targetTuesdayLocalMs = localMs >= thisTuesday19LocalMs
-    ? thisTuesday19LocalMs + WEEK_MS
-    : thisTuesday19LocalMs;
-
-  return getWeekInfoFromShanghaiLocalMs(targetTuesdayLocalMs);
-}
-
-function getLastClosedWeekByTuesday19(date = new Date()) {
-  const localMs = getShanghaiLocalMs(date);
-  const thisTuesday19LocalMs = getThisWeekTuesday19LocalMs(localMs);
-  const targetTuesdayLocalMs = localMs >= thisTuesday19LocalMs
+  const startLocalMs = localMs >= thisTuesday19LocalMs
     ? thisTuesday19LocalMs
     : thisTuesday19LocalMs - WEEK_MS;
 
-  return getWeekInfoFromShanghaiLocalMs(targetTuesdayLocalMs);
+  return {
+    startLocalMs,
+    endLocalMs: startLocalMs + WEEK_MS
+  };
+}
+
+function getLastClosedWeekWindowLocalMs(date = new Date()) {
+  const localMs = getShanghaiLocalMs(date);
+  const thisTuesday19LocalMs = getThisWeekTuesday19LocalMs(localMs);
+  const endLocalMs = localMs >= thisTuesday19LocalMs
+    ? thisTuesday19LocalMs
+    : thisTuesday19LocalMs - WEEK_MS;
+
+  return {
+    startLocalMs: endLocalMs - WEEK_MS,
+    endLocalMs
+  };
+}
+
+function getCurrentWeekByTuesday19(date = new Date()) {
+  const { endLocalMs } = getCurrentWeekWindowLocalMs(date);
+
+  return getWeekInfoFromShanghaiLocalMs(endLocalMs);
+}
+
+function getLastClosedWeekByTuesday19(date = new Date()) {
+  const { endLocalMs } = getLastClosedWeekWindowLocalMs(date);
+
+  return getWeekInfoFromShanghaiLocalMs(endLocalMs);
+}
+
+function getLegacyCurrentWeekByTuesday19(date = new Date()) {
+  const nowInShanghai = new Date(date.getTime() + SHANGHAI_TZ);
+  const dayOfWeek = nowInShanghai.getDay();
+  const hours = nowInShanghai.getHours();
+  const minutes = nowInShanghai.getMinutes();
+
+  const isPastTuesday19 = dayOfWeek > 2 || (dayOfWeek === 2 && (hours > 19 || (hours === 19 && minutes >= 0)));
+
+  const d = new Date(date.getTime());
+  if (isPastTuesday19) {
+    d.setDate(d.getDate() + 7);
+  }
+  const start = new Date(d.getFullYear(), 0, 1);
+  const diff = d - start;
+  return {
+    year: d.getFullYear(),
+    week: Math.floor(diff / WEEK_MS)
+  };
+}
+
+function weekKey(weekInfo) {
+  return `${weekInfo.year}-${weekInfo.week}`;
+}
+
+function dateFromShanghaiLocalMs(localMs) {
+  return new Date(localMs - SHANGHAI_TZ);
+}
+
+function getCompatibleWeekKeysForWindow(startLocalMs, endLocalMs) {
+  const keys = new Map();
+
+  const addKey = weekInfo => {
+    keys.set(weekKey(weekInfo), weekInfo);
+  };
+
+  addKey(getWeekInfoFromShanghaiLocalMs(endLocalMs));
+
+  for (let sampleLocalMs = startLocalMs; sampleLocalMs < endLocalMs; sampleLocalMs += DAY_MS) {
+    addKey(getLegacyCurrentWeekByTuesday19(dateFromShanghaiLocalMs(sampleLocalMs)));
+  }
+  addKey(getLegacyCurrentWeekByTuesday19(dateFromShanghaiLocalMs(endLocalMs - 1)));
+
+  return Array.from(keys.values());
+}
+
+function getCompatibleCurrentWeekKeysByTuesday19(date = new Date()) {
+  const { startLocalMs, endLocalMs } = getCurrentWeekWindowLocalMs(date);
+  return getCompatibleWeekKeysForWindow(startLocalMs, endLocalMs);
+}
+
+function getCompatibleLastClosedWeekKeysByTuesday19(date = new Date()) {
+  const { startLocalMs, endLocalMs } = getLastClosedWeekWindowLocalMs(date);
+  return getCompatibleWeekKeysForWindow(startLocalMs, endLocalMs);
+}
+
+function isWeekKeyIncluded(weekKeys, year, week) {
+  return weekKeys.some(weekInfo => weekInfo.year === year && weekInfo.week === week);
 }
 
 module.exports = {
   getWeekNumber,
   getYear,
   getCurrentWeekByTuesday19,
-  getLastClosedWeekByTuesday19
+  getLastClosedWeekByTuesday19,
+  getCompatibleCurrentWeekKeysByTuesday19,
+  getCompatibleLastClosedWeekKeysByTuesday19,
+  isWeekKeyIncluded
 };

--- a/weekNumber.js
+++ b/weekNumber.js
@@ -1,5 +1,9 @@
 // 上海时区偏移 +8h
+const DAY_MS = 24 * 60 * 60 * 1000;
+const WEEK_MS = 7 * DAY_MS;
 const SHANGHAI_TZ = 8 * 60 * 60 * 1000;
+const TUESDAY = 2;
+const MATCH_OPEN_HOUR = 19;
 
 function getWeekNumber(date = new Date()) {
   const d = new Date(date.getTime());
@@ -12,28 +16,57 @@ function getYear(date = new Date()) {
   return date.getFullYear();
 }
 
-function getCurrentWeekByTuesday19(date = new Date()) {
-  const nowInShanghai = new Date(date.getTime() + SHANGHAI_TZ);
-  const dayOfWeek = nowInShanghai.getDay();
-  const hours = nowInShanghai.getHours();
-  const minutes = nowInShanghai.getMinutes();
+function getShanghaiLocalMs(date) {
+  return date.getTime() + SHANGHAI_TZ;
+}
 
-  const isPastTuesday19 = dayOfWeek > 2 || (dayOfWeek === 2 && (hours > 19 || (hours === 19 && minutes >= 0)));
-
-  const d = new Date(date.getTime());
-  if (isPastTuesday19) {
-    d.setDate(d.getDate() + 7);
-  }
-  const start = new Date(d.getFullYear(), 0, 1);
-  const diff = d - start;
+function getWeekInfoFromShanghaiLocalMs(localMs) {
+  const localDate = new Date(localMs);
+  const year = localDate.getUTCFullYear();
+  const startOfYearLocalMs = Date.UTC(year, 0, 1);
   return {
-    year: d.getFullYear(),
-    week: Math.floor(diff / 604800000)
+    year,
+    week: Math.floor((localMs - startOfYearLocalMs) / WEEK_MS)
   };
+}
+
+function getThisWeekTuesday19LocalMs(localMs) {
+  const localDate = new Date(localMs);
+  const daysSinceTuesday = (localDate.getUTCDay() - TUESDAY + 7) % 7;
+  return Date.UTC(
+    localDate.getUTCFullYear(),
+    localDate.getUTCMonth(),
+    localDate.getUTCDate() - daysSinceTuesday,
+    MATCH_OPEN_HOUR,
+    0,
+    0,
+    0
+  );
+}
+
+function getCurrentWeekByTuesday19(date = new Date()) {
+  const localMs = getShanghaiLocalMs(date);
+  const thisTuesday19LocalMs = getThisWeekTuesday19LocalMs(localMs);
+  const targetTuesdayLocalMs = localMs >= thisTuesday19LocalMs
+    ? thisTuesday19LocalMs + WEEK_MS
+    : thisTuesday19LocalMs;
+
+  return getWeekInfoFromShanghaiLocalMs(targetTuesdayLocalMs);
+}
+
+function getLastClosedWeekByTuesday19(date = new Date()) {
+  const localMs = getShanghaiLocalMs(date);
+  const thisTuesday19LocalMs = getThisWeekTuesday19LocalMs(localMs);
+  const targetTuesdayLocalMs = localMs >= thisTuesday19LocalMs
+    ? thisTuesday19LocalMs
+    : thisTuesday19LocalMs - WEEK_MS;
+
+  return getWeekInfoFromShanghaiLocalMs(targetTuesdayLocalMs);
 }
 
 module.exports = {
   getWeekNumber,
   getYear,
-  getCurrentWeekByTuesday19
+  getCurrentWeekByTuesday19,
+  getLastClosedWeekByTuesday19
 };

--- a/weekNumber.js
+++ b/weekNumber.js
@@ -127,6 +127,36 @@ function getCompatibleWeekKeysForWindow(startLocalMs, endLocalMs) {
   return Array.from(keys.values());
 }
 
+function getTuesday19LocalMsForWeekInfo(year, week) {
+  const bucketStartLocalMs = Date.UTC(year, 0, 1) + week * WEEK_MS;
+
+  for (let offsetDays = 0; offsetDays < 7; offsetDays += 1) {
+    const candidateLocalMs = bucketStartLocalMs + offsetDays * DAY_MS + MATCH_OPEN_HOUR * 60 * 60 * 1000;
+    const candidateLocalDate = new Date(candidateLocalMs);
+    const candidateWeekInfo = getWeekInfoFromShanghaiLocalMs(candidateLocalMs);
+
+    if (
+      candidateLocalDate.getUTCDay() === TUESDAY
+      && candidateWeekInfo.year === year
+      && candidateWeekInfo.week === week
+    ) {
+      return candidateLocalMs;
+    }
+  }
+
+  return null;
+}
+
+function getCompatibleWeekKeysForWeek(year, week) {
+  const endLocalMs = getTuesday19LocalMsForWeekInfo(year, week);
+
+  if (endLocalMs === null) {
+    return [{ year, week }];
+  }
+
+  return getCompatibleWeekKeysForWindow(endLocalMs - WEEK_MS, endLocalMs);
+}
+
 function getCompatibleCurrentWeekKeysByTuesday19(date = new Date()) {
   const { startLocalMs, endLocalMs } = getCurrentWeekWindowLocalMs(date);
   return getCompatibleWeekKeysForWindow(startLocalMs, endLocalMs);
@@ -146,6 +176,7 @@ module.exports = {
   getYear,
   getCurrentWeekByTuesday19,
   getLastClosedWeekByTuesday19,
+  getCompatibleWeekKeysForWeek,
   getCompatibleCurrentWeekKeysByTuesday19,
   getCompatibleLastClosedWeekKeysByTuesday19,
   isWeekKeyIncluded

--- a/weekNumber.js
+++ b/weekNumber.js
@@ -106,6 +106,10 @@ function weekKey(weekInfo) {
   return `${weekInfo.year}-${weekInfo.week}`;
 }
 
+function isSameWeekInfo(a, b) {
+  return a?.year === b?.year && a?.week === b?.week;
+}
+
 function dateFromShanghaiLocalMs(localMs) {
   return new Date(localMs - SHANGHAI_TZ);
 }
@@ -125,6 +129,20 @@ function getCompatibleWeekKeysForWindow(startLocalMs, endLocalMs) {
   addKey(getLegacyCurrentWeekByTuesday19(dateFromShanghaiLocalMs(endLocalMs - 1)));
 
   return Array.from(keys.values());
+}
+
+function getConfirmationWindowInfo(startLocalMs, endLocalMs) {
+  const canonicalWeek = getWeekInfoFromShanghaiLocalMs(endLocalMs);
+  const weekKeys = getCompatibleWeekKeysForWindow(startLocalMs, endLocalMs);
+  const legacyWeekKeys = weekKeys.filter(weekInfo => !isSameWeekInfo(weekInfo, canonicalWeek));
+
+  return {
+    startAt: dateFromShanghaiLocalMs(startLocalMs),
+    endAt: dateFromShanghaiLocalMs(endLocalMs),
+    canonicalWeek,
+    weekKeys,
+    legacyWeekKeys
+  };
 }
 
 function getTuesday19LocalMsForWeekInfo(year, week) {
@@ -157,6 +175,33 @@ function getCompatibleWeekKeysForWeek(year, week) {
   return getCompatibleWeekKeysForWindow(endLocalMs - WEEK_MS, endLocalMs);
 }
 
+function getCurrentConfirmationWindowByTuesday19(date = new Date()) {
+  const { startLocalMs, endLocalMs } = getCurrentWeekWindowLocalMs(date);
+  return getConfirmationWindowInfo(startLocalMs, endLocalMs);
+}
+
+function getLastClosedConfirmationWindowByTuesday19(date = new Date()) {
+  const { startLocalMs, endLocalMs } = getLastClosedWeekWindowLocalMs(date);
+  return getConfirmationWindowInfo(startLocalMs, endLocalMs);
+}
+
+function getConfirmationWindowForWeek(year, week) {
+  const endLocalMs = getTuesday19LocalMsForWeekInfo(year, week);
+
+  if (endLocalMs === null) {
+    const canonicalWeek = { year, week };
+    return {
+      startAt: null,
+      endAt: null,
+      canonicalWeek,
+      weekKeys: [canonicalWeek],
+      legacyWeekKeys: []
+    };
+  }
+
+  return getConfirmationWindowInfo(endLocalMs - WEEK_MS, endLocalMs);
+}
+
 function getCompatibleCurrentWeekKeysByTuesday19(date = new Date()) {
   const { startLocalMs, endLocalMs } = getCurrentWeekWindowLocalMs(date);
   return getCompatibleWeekKeysForWindow(startLocalMs, endLocalMs);
@@ -171,13 +216,51 @@ function isWeekKeyIncluded(weekKeys, year, week) {
   return weekKeys.some(weekInfo => weekInfo.year === year && weekInfo.week === week);
 }
 
+function isDateInConfirmationWindow(date, confirmationWindow) {
+  if (!date || !confirmationWindow?.startAt || !confirmationWindow?.endAt) {
+    return false;
+  }
+
+  const confirmedAt = date instanceof Date ? date : new Date(date);
+  const confirmedMs = confirmedAt.getTime();
+
+  return !Number.isNaN(confirmedMs)
+    && confirmedMs >= confirmationWindow.startAt.getTime()
+    && confirmedMs < confirmationWindow.endAt.getTime();
+}
+
+function isConfirmationIncludedInWindow(confirmationWindow, year, week, confirmedAt = null) {
+  const parsedYear = Number.parseInt(year, 10);
+  const parsedWeek = Number.parseInt(week, 10);
+
+  if (Number.isNaN(parsedYear) || Number.isNaN(parsedWeek)) {
+    return false;
+  }
+
+  const candidate = { year: parsedYear, week: parsedWeek };
+
+  if (isSameWeekInfo(candidate, confirmationWindow?.canonicalWeek)) {
+    return isDateInConfirmationWindow(confirmedAt, confirmationWindow);
+  }
+
+  if (isWeekKeyIncluded(confirmationWindow?.legacyWeekKeys || [], parsedYear, parsedWeek)) {
+    return confirmedAt == null || isDateInConfirmationWindow(confirmedAt, confirmationWindow);
+  }
+
+  return false;
+}
+
 module.exports = {
   getWeekNumber,
   getYear,
   getCurrentWeekByTuesday19,
   getLastClosedWeekByTuesday19,
   getCompatibleWeekKeysForWeek,
+  getCurrentConfirmationWindowByTuesday19,
+  getLastClosedConfirmationWindowByTuesday19,
+  getConfirmationWindowForWeek,
   getCompatibleCurrentWeekKeysByTuesday19,
   getCompatibleLastClosedWeekKeysByTuesday19,
+  isConfirmationIncludedInWindow,
   isWeekKeyIncluded
 };

--- a/weekNumber.test.js
+++ b/weekNumber.test.js
@@ -5,8 +5,12 @@ const {
   getCurrentWeekByTuesday19,
   getLastClosedWeekByTuesday19,
   getCompatibleWeekKeysForWeek,
+  getCurrentConfirmationWindowByTuesday19,
+  getLastClosedConfirmationWindowByTuesday19,
+  getConfirmationWindowForWeek,
   getCompatibleCurrentWeekKeysByTuesday19,
   getCompatibleLastClosedWeekKeysByTuesday19,
+  isConfirmationIncludedInWindow,
   isWeekKeyIncluded
 } = require('./weekNumber');
 
@@ -73,6 +77,44 @@ test('explicit rerun compatible keys match the matching window for that week', (
   assert.deepEqual(
     sortedWeekKeys(getCompatibleWeekKeysForWeek(2026, 17)),
     sortedWeekKeys(getCompatibleLastClosedWeekKeysByTuesday19(new Date('2026-05-05T19:00:00+08:00')))
+  );
+});
+
+test('current confirmation status requires a timestamp for the canonical key', () => {
+  const currentWindow = getCurrentConfirmationWindowByTuesday19(new Date('2026-05-05T19:01:00+08:00'));
+
+  assert.equal(isConfirmationIncludedInWindow(currentWindow, 2026, 18, null), false);
+  assert.equal(
+    isConfirmationIncludedInWindow(currentWindow, 2026, 18, new Date('2026-05-05T19:01:00+08:00')),
+    true
+  );
+});
+
+test('active windows can still honor legacy untimestamped keys before they collide', () => {
+  const currentWindow = getCurrentConfirmationWindowByTuesday19(new Date('2026-04-30T20:00:00+08:00'));
+
+  assert.equal(isConfirmationIncludedInWindow(currentWindow, 2026, 18, null), true);
+});
+
+test('closed-cycle matching excludes new confirmations after the boundary', () => {
+  const closedWindow = getLastClosedConfirmationWindowByTuesday19(new Date('2026-05-05T19:05:00+08:00'));
+
+  assert.equal(
+    isConfirmationIncludedInWindow(closedWindow, 2026, 18, new Date('2026-05-05T19:01:00+08:00')),
+    false
+  );
+  assert.equal(
+    isConfirmationIncludedInWindow(closedWindow, 2026, 18, new Date('2026-05-05T18:59:00+08:00')),
+    true
+  );
+});
+
+test('explicit reruns do not include later-cycle confirmations', () => {
+  const rerunWindow = getConfirmationWindowForWeek(2026, 17);
+
+  assert.equal(
+    isConfirmationIncludedInWindow(rerunWindow, 2026, 18, new Date('2026-05-05T19:01:00+08:00')),
+    false
   );
 });
 

--- a/weekNumber.test.js
+++ b/weekNumber.test.js
@@ -3,7 +3,10 @@ const test = require('node:test');
 
 const {
   getCurrentWeekByTuesday19,
-  getLastClosedWeekByTuesday19
+  getLastClosedWeekByTuesday19,
+  getCompatibleCurrentWeekKeysByTuesday19,
+  getCompatibleLastClosedWeekKeysByTuesday19,
+  isWeekKeyIncluded
 } = require('./weekNumber');
 
 function weekKey(weekInfo) {
@@ -44,5 +47,38 @@ test('weekly cron targets the cycle that just closed at Tuesday 19:00', () => {
   assert.equal(
     weekKey(getLastClosedWeekByTuesday19(new Date('2026-05-05T19:05:00+08:00'))),
     '2026-17'
+  );
+});
+
+test('compatible keys include legacy keys from the active confirmation window', () => {
+  const keys = getCompatibleCurrentWeekKeysByTuesday19(new Date('2026-04-30T20:00:00+08:00'));
+
+  assert.equal(isWeekKeyIncluded(keys, 2026, 17), true);
+  assert.equal(isWeekKeyIncluded(keys, 2026, 18), true);
+});
+
+test('last closed compatible keys cover users confirmed before the cron boundary', () => {
+  const keys = getCompatibleLastClosedWeekKeysByTuesday19(new Date('2026-05-05T19:00:00+08:00'));
+
+  assert.equal(isWeekKeyIncluded(keys, 2026, 17), true);
+  assert.equal(isWeekKeyIncluded(keys, 2026, 18), true);
+});
+
+test('handles Tuesday 19:00 confirmation cycles across year boundaries', () => {
+  assert.equal(
+    weekKey(getCurrentWeekByTuesday19(new Date('2026-12-29T18:59:00+08:00'))),
+    '2026-51'
+  );
+  assert.equal(
+    weekKey(getCurrentWeekByTuesday19(new Date('2026-12-29T19:00:00+08:00'))),
+    '2027-0'
+  );
+  assert.equal(
+    weekKey(getCurrentWeekByTuesday19(new Date('2027-01-05T18:59:00+08:00'))),
+    '2027-0'
+  );
+  assert.equal(
+    weekKey(getLastClosedWeekByTuesday19(new Date('2027-01-05T19:00:00+08:00'))),
+    '2027-0'
   );
 });

--- a/weekNumber.test.js
+++ b/weekNumber.test.js
@@ -4,6 +4,7 @@ const test = require('node:test');
 const {
   getCurrentWeekByTuesday19,
   getLastClosedWeekByTuesday19,
+  getCompatibleWeekKeysForWeek,
   getCompatibleCurrentWeekKeysByTuesday19,
   getCompatibleLastClosedWeekKeysByTuesday19,
   isWeekKeyIncluded
@@ -11,6 +12,10 @@ const {
 
 function weekKey(weekInfo) {
   return `${weekInfo.year}-${weekInfo.week}`;
+}
+
+function sortedWeekKeys(weekKeys) {
+  return weekKeys.map(weekKey).sort();
 }
 
 test('keeps one confirmation cycle stable between Tuesday 19:00 boundaries', () => {
@@ -62,6 +67,13 @@ test('last closed compatible keys cover users confirmed before the cron boundary
 
   assert.equal(isWeekKeyIncluded(keys, 2026, 17), true);
   assert.equal(isWeekKeyIncluded(keys, 2026, 18), true);
+});
+
+test('explicit rerun compatible keys match the matching window for that week', () => {
+  assert.deepEqual(
+    sortedWeekKeys(getCompatibleWeekKeysForWeek(2026, 17)),
+    sortedWeekKeys(getCompatibleLastClosedWeekKeysByTuesday19(new Date('2026-05-05T19:00:00+08:00')))
+  );
 });
 
 test('handles Tuesday 19:00 confirmation cycles across year boundaries', () => {

--- a/weekNumber.test.js
+++ b/weekNumber.test.js
@@ -1,0 +1,48 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  getCurrentWeekByTuesday19,
+  getLastClosedWeekByTuesday19
+} = require('./weekNumber');
+
+function weekKey(weekInfo) {
+  return `${weekInfo.year}-${weekInfo.week}`;
+}
+
+test('keeps one confirmation cycle stable between Tuesday 19:00 boundaries', () => {
+  const dates = [
+    '2026-04-28T19:00:00+08:00',
+    '2026-04-29T20:00:00+08:00',
+    '2026-04-30T20:00:00+08:00',
+    '2026-05-03T20:00:00+08:00',
+    '2026-05-05T18:59:00+08:00'
+  ];
+
+  assert.deepEqual(
+    dates.map(date => weekKey(getCurrentWeekByTuesday19(new Date(date)))),
+    ['2026-17', '2026-17', '2026-17', '2026-17', '2026-17']
+  );
+});
+
+test('advances the current confirmation cycle at Tuesday 19:00 Shanghai time', () => {
+  assert.equal(
+    weekKey(getCurrentWeekByTuesday19(new Date('2026-05-05T18:59:00+08:00'))),
+    '2026-17'
+  );
+  assert.equal(
+    weekKey(getCurrentWeekByTuesday19(new Date('2026-05-05T19:00:00+08:00'))),
+    '2026-18'
+  );
+});
+
+test('weekly cron targets the cycle that just closed at Tuesday 19:00', () => {
+  assert.equal(
+    weekKey(getLastClosedWeekByTuesday19(new Date('2026-05-05T19:00:00+08:00'))),
+    '2026-17'
+  );
+  assert.equal(
+    weekKey(getLastClosedWeekByTuesday19(new Date('2026-05-05T19:05:00+08:00'))),
+    '2026-17'
+  );
+});


### PR DESCRIPTION
﻿## 背景

用户在同一周内需要多次点击“确认匹配”。排查后发现确认状态本身存储在 `users.weekly_match_year/week`，但 `getCurrentWeekByTuesday19()` 在同一个周二 19:00 周期内会算出不同 week id，导致已保存的确认记录与当前计算结果对不上。

## 修改

- 重写周二 19:00 上海时间确认周期计算，保证一个确认窗口内 week id 稳定。
- 新增 `getLastClosedWeekByTuesday19()`，让 cron 在周二 19:00 执行时匹配刚关闭的确认周期。
- 新增 `weekNumber.test.js` 覆盖确认周期稳定性和 cron 目标周期。
- CI 增加 `npm test`。

## 验证

- `npm test`
- `node --check app.js`
- `node --check database.js`
- `node --check matchService.js`
- `git diff --check`
