### PR TITLE
重构：外置每周匹配页面样式和脚本

### DIFF
--- a/.version.json
+++ b/.version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.3.0",
-  "generatedAt": "2026-04-28T00:00:00.000Z",
+  "generatedAt": "2026-05-04T03:11:16.864Z",
   "resources": {
     "css/account-pages.css": {
       "hash": "1b1d17ce",
@@ -11,8 +11,8 @@
       "version": "0.2.0-1fdea12d"
     },
     "css/style.css": {
-      "hash": "0cd31def",
-      "version": "0.2.0-0cd31def"
+      "hash": "5446cca4",
+      "version": "0.2.0-5446cca4"
     },
     "favicon.ico": {
       "hash": "5ecd6c3b",
@@ -41,6 +41,10 @@
     "js/couple-result.js": {
       "hash": "dacb5796",
       "version": "0.2.0-dacb5796"
+    },
+    "js/match-detail.js": {
+      "hash": "9159358c",
+      "version": "0.2.0-9159358c"
     },
     "js/layout-shell.js": {
       "hash": "2b474f11",

--- a/.version.json
+++ b/.version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "0.2.0",
   "generatedAt": "2026-05-04T03:11:16.864Z",
   "resources": {
     "css/account-pages.css": {
@@ -11,8 +11,8 @@
       "version": "0.2.0-1fdea12d"
     },
     "css/style.css": {
-      "hash": "5446cca4",
-      "version": "0.2.0-5446cca4"
+      "hash": "560c6da3",
+      "version": "0.2.0-560c6da3"
     },
     "favicon.ico": {
       "hash": "5ecd6c3b",

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -767,12 +767,26 @@ body {
 
 .match-card {
   display: flex;
-  align-items: flex-start;
-  gap: 20px;
-  padding: 20px;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 20px;
   border-radius: 16px;
   border: 1px solid var(--border);
   background: var(--surface-soft);
+}
+
+.match-card--link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.match-card--current {
+  border-color: var(--primary);
+  border-width: 2px;
+}
+
+.match-card--no-match {
+  border-color: var(--border);
 }
 
 .match-rank {
@@ -783,9 +797,34 @@ body {
   color: var(--primary);
 }
 
+.match-week {
+  min-width: 90px;
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.match-info,
 .match-summary {
   flex: 1;
   min-width: 0;
+}
+
+.match-partner {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.match-status {
+  font-size: 0.85rem;
+  color: var(--muted-foreground);
+}
+
+.match-status--warn {
+  color: var(--warning);
+}
+
+.match-status--wait {
+  color: var(--primary);
 }
 
 .match-meta {
@@ -802,11 +841,16 @@ body {
 }
 
 .match-score {
+  display: inline-block;
   align-self: center;
   padding: 10px 14px;
   border-radius: 999px;
   font-weight: 700;
   white-space: nowrap;
+}
+
+.match-score--compact {
+  margin-top: 4px;
 }
 
 .match-score--high {
@@ -822,6 +866,63 @@ body {
 .match-score--low {
   background: oklch(0.95 0.08 25);
   color: oklch(0.45 0.15 25);
+}
+
+.match-detail-link {
+  display: inline-block;
+  margin-top: 6px;
+  font-size: 0.85rem;
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.match-detail-link:hover {
+  text-decoration: underline;
+}
+
+.match-card__action {
+  color: var(--muted-foreground);
+  font-size: 0.85rem;
+}
+
+.match-empty-card {
+  text-align: center;
+}
+
+.match-empty-icon {
+  font-size: 4rem;
+  margin-bottom: 16px;
+}
+
+.match-empty-text {
+  color: var(--muted-foreground);
+}
+
+.match-empty-text--spaced {
+  margin-bottom: 24px;
+}
+
+.match-action-link {
+  margin-top: 16px;
+}
+
+.match-section-title {
+  margin: 0 0 16px 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.match-section-title--simple {
+  display: block;
+}
+
+.match-section-title--muted {
+  color: var(--muted-foreground);
+}
+
+.match-history-section {
+  margin-top: 16px;
 }
 
 .match-comment {
@@ -842,9 +943,136 @@ body {
   white-space: pre-line;
 }
 
+.match-detail-shell {
+  max-width: 600px;
+  padding-top: 40px;
+}
+
+.match-detail-backbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.match-detail-backlink {
+  color: var(--muted-foreground);
+  text-decoration: none;
+}
+
+.match-detail-backlink:hover {
+  color: var(--primary);
+}
+
+.detail-score {
+  text-align: center;
+  padding: 32px;
+  border-radius: 16px;
+  margin-bottom: 24px;
+  background: var(--accent);
+}
+
+.detail-score .label {
+  color: var(--muted-foreground);
+  margin-bottom: 8px;
+}
+
+.detail-score .score {
+  font-size: 64px;
+  font-weight: bold;
+}
+
+.detail-score .score--high {
+  color: oklch(0.55 0.15 145);
+}
+
+.detail-score .score--medium {
+  color: oklch(0.6 0.15 80);
+}
+
+.detail-score .score--low {
+  color: oklch(0.6 0.15 25);
+}
+
+.detail-info {
+  padding: 20px;
+  background: var(--accent);
+  border-radius: 12px;
+  margin-bottom: 20px;
+}
+
+.detail-info h3 {
+  margin: 0 0 16px 0;
+  font-size: 1.1rem;
+}
+
+.detail-info p {
+  margin: 0;
+  padding: 8px 0;
+  display: flex;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+}
+
+.detail-info p:first-of-type {
+  border-top: 1px solid var(--border);
+}
+
+.detail-info p:last-child {
+  border-bottom: none;
+}
+
+.detail-info .label {
+  color: var(--muted-foreground);
+}
+
+.detail-info__text {
+  display: block;
+  border: none;
+  padding: 0;
+}
+
+.detail-comment {
+  padding: 20px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  margin-bottom: 24px;
+}
+
+.detail-comment h3 {
+  margin: 0 0 12px 0;
+  font-size: 1rem;
+}
+
+.detail-comment p {
+  margin: 0;
+  line-height: 1.7;
+  color: var(--muted-foreground);
+  white-space: pre-line;
+}
+
+.match-detail-note {
+  font-size: 0.85rem;
+  color: var(--muted-foreground);
+  text-align: center;
+  margin-bottom: 24px;
+}
+
+.match-detail-empty {
+  text-align: center;
+  padding: 40px;
+}
+
+.match-detail-actions {
+  text-align: center;
+  margin-top: 24px;
+}
+
 @media (max-width: 700px) {
   .match-card {
     flex-direction: column;
+    align-items: flex-start;
     gap: 14px;
   }
 
@@ -863,6 +1091,10 @@ body {
 
   .match-score {
     align-self: flex-start;
+  }
+
+  .match-week {
+    min-width: 0;
   }
 }
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -868,18 +868,6 @@ body {
   color: oklch(0.45 0.15 25);
 }
 
-.match-detail-link {
-  display: inline-block;
-  margin-top: 6px;
-  font-size: 0.85rem;
-  color: var(--primary);
-  text-decoration: none;
-}
-
-.match-detail-link:hover {
-  text-decoration: underline;
-}
-
 .match-card__action {
   color: var(--muted-foreground);
   font-size: 0.85rem;

--- a/public/js/match-detail.js
+++ b/public/js/match-detail.js
@@ -1,0 +1,40 @@
+(function() {
+  function setComment(commentEl, message) {
+    var text = commentEl.querySelector('[data-match-comment-text]');
+    if (!text) return;
+    text.textContent = message;
+  }
+
+  function initMatchComment() {
+    var commentEl = document.querySelector('[data-match-comment-url]');
+    if (!commentEl) return;
+
+    var url = commentEl.dataset.matchCommentUrl;
+    if (!url) return;
+
+    fetch(url, {
+      headers: {
+        Accept: 'application/json'
+      }
+    })
+      .then(function(res) {
+        if (!res.ok) {
+          throw new Error('Failed to load match comment');
+        }
+        return res.json();
+      })
+      .then(function(data) {
+        var comment = data && typeof data.comment === 'string' ? data.comment.trim() : '';
+        setComment(commentEl, data && data.success && comment ? comment : '暂无可用评语');
+      })
+      .catch(function() {
+        setComment(commentEl, '加载失败');
+      });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initMatchComment, { once: true });
+  } else {
+    initMatchComment();
+  }
+})();

--- a/views/match-detail.ejs
+++ b/views/match-detail.ejs
@@ -1,88 +1,29 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>匹配详情 - 心有所SHU</title>
-  <link rel="stylesheet" href="/css/style.css?v=0.2.0">
-  <%- include('partials/head-icons') %>
-  <% if (typeof isDev !== 'undefined' && isDev) { %>
-  <link rel="stylesheet" href="/css/dev-tools.css?v=bottom-right">
+  <%
+    const shouldLoadMatchComment = typeof matchId !== 'undefined' && matchId && !(typeof weeklyMatch !== 'undefined' && weeklyMatch && weeklyMatch.matchComment);
+  %>
+  <%- include('partials/document-head', { pageTitle: '匹配详情', devToolsStyles: true }) %>
+  <% if (shouldLoadMatchComment) { %>
+  <script src="/js/match-detail.js?v=0.2.0" defer></script>
   <% } %>
-  <style>
-    .detail-score {
-      text-align: center;
-      padding: 32px;
-      border-radius: 16px;
-      margin-bottom: 24px;
-    }
-    .detail-score .label {
-      color: var(--muted-foreground);
-      margin-bottom: 8px;
-    }
-    .detail-score .score {
-      font-size: 64px;
-      font-weight: bold;
-    }
-    .detail-info {
-      padding: 20px;
-      background: var(--accent);
-      border-radius: 12px;
-      margin-bottom: 20px;
-    }
-    .detail-info h3 {
-      margin: 0 0 16px 0;
-      font-size: 1.1rem;
-    }
-    .detail-info p {
-      margin: 0;
-      padding: 8px 0;
-      display: flex;
-      justify-content: space-between;
-      border-bottom: 1px solid var(--border);
-    }
-    .detail-info p:first-child {
-      border-top: 1px solid var(--border);
-    }
-    .detail-info p:last-child {
-      border-bottom: none;
-    }
-    .detail-info .label {
-      color: var(--muted-foreground);
-    }
-    .detail-comment {
-      padding: 20px;
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      margin-bottom: 24px;
-    }
-    .detail-comment h3 {
-      margin: 0 0 12px 0;
-      font-size: 1rem;
-    }
-    .detail-comment p {
-      margin: 0;
-      line-height: 1.7;
-      color: var(--muted-foreground);
-      white-space: pre-line;
-    }
-  </style>
 </head>
 <body>
   <%- include('partials/navbar') %>
 
-  <div class="container" style="max-width: 600px; padding-top: 40px;">
+  <div class="container match-detail-shell">
     <div class="card">
-      <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 24px;">
-        <a href="/matches" style="text-decoration: none; color: var(--muted-foreground);">← 返回</a>
+      <div class="match-detail-backbar">
+        <a href="/matches" class="match-detail-backlink">← 返回</a>
       </div>
 
       <% if (matches && matches.length > 0) { %>
         <% var m = matches[0]; %>
-        <div class="detail-score" style="background: var(--accent);">
+        <% const detailScoreTone = m.score >= 70 ? 'high' : (m.score >= 50 ? 'medium' : 'low'); %>
+        <div class="detail-score">
           <div class="label">与 <%= m.nickname || m.email %> 的匹配度</div>
-          <div class="score" style="color: <%= m.score >= 70 ? 'oklch(0.55 0.15 145)' : m.score >= 50 ? 'oklch(0.6 0.15 80)' : 'oklch(0.6 0.15 25)' %>;">
+          <div class="score score--<%= detailScoreTone %>">
             <%= m.score !== null && m.score !== undefined ? Math.round(m.score) : '--' %>分
           </div>
         </div>
@@ -93,9 +34,9 @@
           <p><%= weeklyMatch.matchComment %></p>
         </div>
         <% } else if (typeof matchId !== 'undefined' && matchId) { %>
-        <div class="detail-comment" id="match-comment" data-match-id="<%= matchId %>">
+        <div class="detail-comment" data-match-comment-url="/api/weekly-match/comment/<%= matchId %>">
           <h3>💕 AI 智能匹配评语</h3>
-          <p style="color: var(--muted-foreground);">加载AI评语中...</p>
+          <p data-match-comment-text>加载AI评语中...</p>
         </div>
         <% } %>
 
@@ -109,7 +50,7 @@
           <p><span class="label">学校邮箱</span><span><%= m.email || '未填写' %></span></p>
         </div>
 
-        <p style="font-size: 0.85rem; color: var(--muted-foreground); text-align: center; margin-bottom: 24px;">
+        <p class="match-detail-note">
           请尊重对方意愿，合理使用联系邮箱。
         </p>
 
@@ -117,21 +58,21 @@
           <h3>对方的兴趣爱好</h3>
           <% var interestList = (m.interests || '').split(',').filter(function(i) { return i; }); %>
           <% if (interestList.length > 0) { %>
-          <p style="display: block; border: none; padding: 0;">
+          <p class="detail-info__text">
             <%= interestList.map(function(i) { return i.replace(/^[^|-]+[|-]/, ''); }).join(', ') %>
           </p>
           <% } else { %>
-          <p style="display: block; border: none; padding: 0;">未填写</p>
+          <p class="detail-info__text">未填写</p>
           <% } %>
         </div>
       <% } else { %>
-        <div style="text-align: center; padding: 40px;">
-          <p style="color: var(--muted-foreground);">未找到匹配信息</p>
-          <a href="/matches" class="btn btn-secondary" style="margin-top: 16px;">返回</a>
+        <div class="match-detail-empty">
+          <p class="match-empty-text">未找到匹配信息</p>
+          <a href="/matches" class="btn btn-secondary match-action-link">返回</a>
         </div>
       <% } %>
 
-      <div style="text-align: center; margin-top: 24px;">
+      <div class="match-detail-actions">
         <a href="/matches" class="btn btn-secondary">返回匹配列表</a>
       </div>
     </div>
@@ -141,29 +82,6 @@
 
   <% if (typeof isDev !== 'undefined' && isDev) { %>
   <%- include('partials/dev-tools') %>
-  <% } %>
-
-  <% if (typeof matchId !== 'undefined' && matchId && !(typeof weeklyMatch !== 'undefined' && weeklyMatch && weeklyMatch.matchComment)) { %>
-  <script>
-    (function() {
-      const commentEl = document.getElementById('match-comment');
-      const matchId = commentEl?.dataset.matchId;
-      if (!matchId) return;
-
-      fetch('/api/weekly-match/comment/' + matchId)
-        .then(function(res) { return res.json(); })
-        .then(function(data) {
-          if (data.success && data.comment) {
-            commentEl.querySelector('p').textContent = data.comment;
-          } else {
-            commentEl.querySelector('p').textContent = '暂无可用评语';
-          }
-        })
-        .catch(function() {
-          commentEl.querySelector('p').textContent = '加载失败';
-        });
-    })();
-  </script>
   <% } %>
 </body>
 </html>

--- a/views/matches.ejs
+++ b/views/matches.ejs
@@ -1,131 +1,60 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
-<%- include('partials/document-head', { pageTitle: '匹配结果', devToolsStyles: true }) %>
-  <style>
-    .match-list {
-      display: grid;
-      gap: 16px;
-    }
-    .match-card {
-      display: flex;
-      align-items: center;
-      gap: 16px;
-      padding: 16px 20px;
-      border-radius: 16px;
-      border: 1px solid var(--border);
-      background: var(--surface-soft);
-    }
-    .match-card--current {
-      border-color: var(--primary);
-      border-width: 2px;
-    }
-    .match-card--no-match {
-      border-color: var(--border);
-    }
-    .match-week {
-      min-width: 90px;
-      font-weight: 700;
-      font-size: 1.1rem;
-    }
-    .match-info {
-      flex: 1;
-      min-width: 0;
-    }
-    .match-partner {
-      font-weight: 600;
-      margin-bottom: 4px;
-    }
-    .match-status {
-      font-size: 0.85rem;
-      color: var(--muted-foreground);
-    }
-    .match-status--warn {
-      color: var(--warning);
-    }
-    .match-status--wait {
-      color: var(--primary);
-    }
-    .match-score {
-      padding: 8px 14px;
-      border-radius: 999px;
-      font-weight: 700;
-      white-space: nowrap;
-    }
-    .match-detail-link {
-      display: inline-block;
-      margin-top: 6px;
-      font-size: 0.85rem;
-      color: var(--primary);
-      text-decoration: none;
-    }
-    .match-detail-link:hover {
-      text-decoration: underline;
-    }
-    @media (max-width: 700px) {
-      .match-card {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 10px;
-      }
-      .match-week {
-        min-width: 0;
-      }
-    }
-  </style>
+  <%- include('partials/document-head', { pageTitle: '匹配结果', devToolsStyles: true }) %>
 </head>
 <body>
   <%- include('partials/navbar') %>
 
   <div class="container">
     <% if (!user.verified) { %>
-    <div class="card" style="text-align: center;">
-      <div style="font-size: 4rem; margin-bottom: 16px;">⚠️</div>
+    <div class="card match-empty-card">
+      <div class="match-empty-icon">⚠️</div>
       <h2>邮箱未验证</h2>
-      <p style="color: var(--muted-foreground);">请先完成邮箱验证后查看匹配结果。</p>
+      <p class="match-empty-text">请先完成邮箱验证后查看匹配结果。</p>
     </div>
     <% } else if (typeof weeklyMatchEnabled !== 'undefined' && !weeklyMatchEnabled) { %>
-    <div class="card" style="text-align: center;">
-      <div style="font-size: 4rem; margin-bottom: 16px;">🔒</div>
+    <div class="card match-empty-card">
+      <div class="match-empty-icon">🔒</div>
       <h2>每周匹配暂未开启</h2>
-      <p style="color: var(--muted-foreground);">该功能正在调试中，开放时间请留意通知。</p>
+      <p class="match-empty-text">该功能正在调试中，开放时间请留意通知。</p>
     </div>
     <% } else if (!hasProfile) { %>
-    <div class="card" style="text-align: center;">
-      <div style="font-size: 4rem; margin-bottom: 16px;">📋</div>
+    <div class="card match-empty-card">
+      <div class="match-empty-icon">📋</div>
       <h2>请先填写问卷</h2>
-      <p style="color: var(--muted-foreground);">需要完成问卷才能查看匹配结果。</p>
-      <a href="/profile" class="btn" style="margin-top: 16px;">去填写问卷</a>
+      <p class="match-empty-text">需要完成问卷才能查看匹配结果。</p>
+      <a href="/profile" class="btn match-action-link">去填写问卷</a>
     </div>
     <% } else { %>
 
     <% if (!weeklyMatchConfirmed) { %>
-    <div class="card" style="text-align: center;">
-      <div style="font-size: 4rem; margin-bottom: 16px;">🤝</div>
+    <div class="card match-empty-card">
+      <div class="match-empty-icon">🤝</div>
       <h2>请确认参与本周匹配</h2>
-      <p style="color: var(--muted-foreground); margin-bottom: 24px;">确认后即可参与本周匹配。</p>
+      <p class="match-empty-text match-empty-text--spaced">确认后即可参与本周匹配。</p>
       <a href="/confirm-match" class="btn btn-large">确认参与匹配</a>
     </div>
     <% } %>
 
     <% if (currentWeekEntry) { %>
     <div class="card">
-      <h3 style="margin: 0 0 16px 0; display: flex; align-items: center; gap: 8px;">
+      <h3 class="match-section-title">
         <span>本周</span>
       </h3>
       <% if (currentWeekEntry.status === 'matched') { %>
-      <a href="/matches/detail/<%= currentWeekEntry.matchId %>" class="match-card match-card--current" style="text-decoration: none; color: inherit;">
+      <a href="/matches/detail/<%= currentWeekEntry.matchId %>" class="match-card match-card--current match-card--link">
         <div class="match-week">第<%= currentWeekEntry.weekNumber %>周</div>
         <div class="match-info">
           <div class="match-partner"><%= currentWeekEntry.partner.nickname || currentWeekEntry.partner.email %></div>
           <% if (currentWeekEntry.score !== null && currentWeekEntry.score !== undefined) { %>
           <% const scoreTone = currentWeekEntry.score >= 70 ? 'high' : (currentWeekEntry.score >= 50 ? 'medium' : 'low'); %>
-          <div class="match-score match-score--<%= scoreTone %>" style="display: inline-block; margin-top: 4px;">
+          <div class="match-score match-score--compact match-score--<%= scoreTone %>">
             <%= Math.round(currentWeekEntry.score) %>分
           </div>
           <% } %>
         </div>
-        <div style="color: var(--muted-foreground); font-size: 0.85rem;">查看详情 →</div>
+        <div class="match-card__action">查看详情 →</div>
       </a>
       <% } else if (currentWeekEntry.status === 'waiting') { %>
       <div class="match-card match-card--no-match">
@@ -146,7 +75,7 @@
     </div>
     <% } else if (weeklyMatchConfirmed) { %>
     <div class="card">
-      <h3 style="margin: 0 0 16px 0;">本周</h3>
+      <h3 class="match-section-title match-section-title--simple">本周</h3>
       <div class="match-card match-card--no-match">
         <div class="match-week">第<%= currentWeekInfo.week %>周</div>
         <div class="match-info">
@@ -157,22 +86,22 @@
     <% } %>
 
     <% if (historyList && historyList.length > 0) { %>
-    <div class="card" style="margin-top: 16px;">
-      <h3 style="margin: 0 0 16px 0; color: var(--muted-foreground);">历史匹配</h3>
+    <div class="card match-history-section">
+      <h3 class="match-section-title match-section-title--simple match-section-title--muted">历史匹配</h3>
       <div class="match-list">
         <% historyList.forEach(function(m) { %>
-        <a href="/matches/detail/<%= m.matchId %>" class="match-card" style="text-decoration: none; color: inherit;">
+        <a href="/matches/detail/<%= m.matchId %>" class="match-card match-card--link">
           <div class="match-week">第<%= m.weekNumber %>周</div>
           <div class="match-info">
             <div class="match-partner"><%= m.partner.nickname || m.partner.email %></div>
             <% if (m.score !== null && m.score !== undefined) { %>
             <% const scoreTone = m.score >= 70 ? 'high' : (m.score >= 50 ? 'medium' : 'low'); %>
-            <div class="match-score match-score--<%= scoreTone %>" style="display: inline-block; margin-top: 4px;">
+            <div class="match-score match-score--compact match-score--<%= scoreTone %>">
               <%= Math.round(m.score) %>分
             </div>
             <% } %>
           </div>
-          <div style="color: var(--muted-foreground); font-size: 0.85rem;">查看详情 →</div>
+          <div class="match-card__action">查看详情 →</div>
         </a>
         <% }); %>
       </div>
@@ -180,10 +109,10 @@
     <% } %>
 
     <% if ((!historyList || historyList.length === 0) && !currentWeekEntry) { %>
-    <div class="card" style="text-align: center;">
-      <div style="font-size: 4rem; margin-bottom: 16px;">🔍</div>
+    <div class="card match-empty-card">
+      <div class="match-empty-icon">🔍</div>
       <h2>暂无匹配记录</h2>
-      <p style="color: var(--muted-foreground);">还没有匹配记录，完成问卷并确认参与匹配后会在每周二公布结果。</p>
+      <p class="match-empty-text">还没有匹配记录，完成问卷并确认参与匹配后会在每周二公布结果。</p>
     </div>
     <% } %>
 


### PR DESCRIPTION
## 变更内容
- 将 /matches 新增的每周匹配页面级样式从模板内联 <style> 移入 public/css/style.css。
- 将 /matches/detail 页面接入公共 document-head，复用统一 meta、head-icons 和 dev tools 样式入口。
- 将匹配详情页的页面级样式移入 public/css/style.css。
- 将每周匹配详情页的异步评语加载脚本抽到 public/js/match-detail.js。
- 异步评语继续使用 textContent 写入，避免回到 innerHTML 拼接。
- 更新 .version.json，纳入 style.css 和新增 match-detail.js 的资源 hash。

## 验证
- node --check public/js/match-detail.js
- git diff --check
- EJS render smoke：matches.ejs、match-detail.ejs 的有/无评语路径
- npm test

Refs #125