### PR TITLE
重构：外置小页面和通知页样式

### DIFF
--- a/.version.json
+++ b/.version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.2.0",
-  "generatedAt": "2026-05-04T03:11:16.864Z",
+  "generatedAt": "2026-05-04T03:34:25.916Z",
   "resources": {
     "css/account-pages.css": {
       "hash": "1b1d17ce",
@@ -11,8 +11,8 @@
       "version": "0.2.0-1fdea12d"
     },
     "css/style.css": {
-      "hash": "560c6da3",
-      "version": "0.2.0-560c6da3"
+      "hash": "495ae758",
+      "version": "0.2.0-495ae758"
     },
     "favicon.ico": {
       "hash": "5ecd6c3b",
@@ -41,6 +41,10 @@
     "js/couple-result.js": {
       "hash": "dacb5796",
       "version": "0.2.0-dacb5796"
+    },
+    "js/history-back.js": {
+      "hash": "2eea60ee",
+      "version": "0.2.0-2eea60ee"
     },
     "js/match-detail.js": {
       "hash": "9159358c",

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1167,6 +1167,11 @@ tr:hover td {
   margin-bottom: 0;
 }
 
+.info-title {
+  font-size: 2rem;
+  margin-bottom: 12px;
+}
+
 .info-meta {
   color: var(--muted-foreground);
   font-size: 0.88rem;
@@ -1199,6 +1204,108 @@ tr:hover td {
 
 .info-section li + li {
   margin-top: 8px;
+}
+
+.message-page {
+  max-width: 640px;
+  padding-top: 96px;
+}
+
+.message-card {
+  text-align: center;
+}
+
+.message-icon {
+  font-size: 3rem;
+  margin-bottom: 16px;
+}
+
+.message-code {
+  color: var(--muted-foreground);
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+}
+
+.message-title {
+  font-size: 2rem;
+  margin-bottom: 12px;
+}
+
+.message-text {
+  color: var(--muted-foreground);
+  margin-bottom: 28px;
+}
+
+.message-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+}
+
+.btn-small {
+  padding: 6px 12px;
+  font-size: 14px;
+}
+
+.notification-page {
+  max-width: 600px;
+  padding-top: 40px;
+}
+
+.notification-title {
+  margin-bottom: 24px;
+}
+
+.notification-item {
+  border-bottom: 1px solid var(--border);
+  padding: 16px;
+}
+
+.notification-item--unread {
+  background: var(--accent);
+}
+
+.notification-row {
+  align-items: flex-start;
+  display: flex;
+  justify-content: space-between;
+}
+
+.notification-body {
+  flex: 1;
+}
+
+.notification-content {
+  margin: 0 0 8px;
+}
+
+.notification-time {
+  color: var(--muted-foreground);
+  font-size: 12px;
+  margin: 0;
+}
+
+.notification-actions {
+  display: flex;
+  gap: 8px;
+  margin-left: 16px;
+}
+
+.notification-action {
+  margin-left: 16px;
+}
+
+.inline-form {
+  display: inline;
+}
+
+.notification-empty {
+  color: var(--muted-foreground);
+  padding: 40px 20px;
+  text-align: center;
 }
 
 /* ===== 动画 ===== */

--- a/public/js/history-back.js
+++ b/public/js/history-back.js
@@ -1,0 +1,22 @@
+(function() {
+  function initHistoryBack() {
+    document.addEventListener('click', function(event) {
+      var trigger = event.target.closest('[data-history-back]');
+      if (!trigger) return;
+
+      event.preventDefault();
+      if (window.history.length > 1) {
+        window.history.back();
+        return;
+      }
+
+      window.location.assign('/');
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initHistoryBack, { once: true });
+  } else {
+    initHistoryBack();
+  }
+})();

--- a/views/404.ejs
+++ b/views/404.ejs
@@ -6,19 +6,19 @@
 <body>
   <%- include('partials/navbar') %>
 
-  <div class="container" style="max-width: 640px; padding-top: 96px;">
-    <div class="card" style="text-align: center;">
-      <div style="font-size: 3rem; margin-bottom: 16px;">🧭</div>
-      <p style="color: var(--muted-foreground); font-size: 0.9rem; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 8px;">
+  <div class="container message-page">
+    <div class="card message-card">
+      <div class="message-icon">🧭</div>
+      <p class="message-code">
         <%= typeof statusCode !== 'undefined' ? statusCode : 404 %>
       </p>
-      <h1 style="font-size: 2rem; margin-bottom: 12px;">这个页面不在这里</h1>
-      <p style="color: var(--muted-foreground); margin-bottom: 28px;">
+      <h1 class="message-title">这个页面不在这里</h1>
+      <p class="message-text">
         <%= typeof message !== 'undefined' && message ? message : '你访问的页面不存在，可能已被移动或删除。' %>
       </p>
-      <div style="display: flex; justify-content: center; gap: 12px; flex-wrap: wrap;">
+      <div class="message-actions">
         <a href="/" class="btn">回到首页</a>
-        <a href="/login" class="btn" style="background: var(--muted); color: var(--foreground);">去登录</a>
+        <a href="/login" class="btn btn-secondary">去登录</a>
       </div>
     </div>
   </div>

--- a/views/error.ejs
+++ b/views/error.ejs
@@ -2,23 +2,24 @@
 <html lang="zh-CN">
 <head>
   <%- include('partials/document-head', { pageTitle: typeof title !== 'undefined' ? title : '服务器异常' }) %>
+  <script src="/js/history-back.js?v=0.2.0" defer></script>
 </head>
 <body>
   <%- include('partials/navbar') %>
 
-  <div class="container" style="max-width: 640px; padding-top: 96px;">
-    <div class="card" style="text-align: center;">
-      <div style="font-size: 3rem; margin-bottom: 16px;">⚠️</div>
-      <p style="color: var(--muted-foreground); font-size: 0.9rem; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 8px;">
+  <div class="container message-page">
+    <div class="card message-card">
+      <div class="message-icon">⚠️</div>
+      <p class="message-code">
         <%= typeof statusCode !== 'undefined' ? statusCode : 500 %>
       </p>
-      <h1 style="font-size: 2rem; margin-bottom: 12px;">服务器出了点问题</h1>
-      <p style="color: var(--muted-foreground); margin-bottom: 28px;">
+      <h1 class="message-title">服务器出了点问题</h1>
+      <p class="message-text">
         <%= typeof message !== 'undefined' && message ? message : '服务器内部错误，请稍后再试。' %>
       </p>
-      <div style="display: flex; justify-content: center; gap: 12px; flex-wrap: wrap;">
+      <div class="message-actions">
         <a href="/" class="btn">返回首页</a>
-        <button type="button" class="btn" onclick="history.back()" style="background: var(--muted); color: var(--foreground);">
+        <button type="button" class="btn btn-secondary" data-history-back>
           返回上一页
         </button>
       </div>

--- a/views/info-page.ejs
+++ b/views/info-page.ejs
@@ -9,7 +9,7 @@
   <div class="container info-page">
     <div class="card">
       <p class="info-meta">最后更新：<%= updatedAt %></p>
-      <h1 style="font-size: 2rem; margin-bottom: 12px;"><%= pageTitle %></h1>
+      <h1 class="info-title"><%= pageTitle %></h1>
       <p class="info-lead"><%= lead %></p>
 
       <% sections.forEach(function(section) { %>

--- a/views/notifications.ejs
+++ b/views/notifications.ejs
@@ -6,12 +6,12 @@
 <body>
   <%- include('partials/navbar') %>
 
-  <div class="container" style="max-width: 600px; padding-top: 40px;">
+  <div class="container notification-page">
     <div class="card">
-      <h2 style="margin-bottom: 24px;">通知中心</h2>
+      <h2 class="notification-title">通知中心</h2>
 
       <% if (typeof message !== 'undefined' && message) { %>
-        <div class="alert alert-<%= messageType || 'info' %>" style="margin-bottom: 20px;">
+        <div class="alert alert-<%= messageType || 'info' %>">
           <%= message %>
         </div>
       <% } %>
@@ -19,28 +19,28 @@
       <% if (notifications && notifications.length > 0) { %>
         <div class="notification-list">
           <% notifications.forEach(function(notification) { %>
-            <div class="notification-item" style="padding: 16px; border-bottom: 1px solid var(--border); <% if (!notification.is_read) { %>background: var(--accent);<% } %>">
-              <div style="display: flex; justify-content: space-between; align-items: start;">
-                <div style="flex: 1;">
-                  <p style="margin: 0 0 8px 0;"><%= notification.content %></p>
-                  <p style="margin: 0; font-size: 12px; color: var(--muted-foreground);">
+            <div class="notification-item<%= !notification.is_read ? ' notification-item--unread' : '' %>">
+              <div class="notification-row">
+                <div class="notification-body">
+                  <p class="notification-content"><%= notification.content %></p>
+                  <p class="notification-time">
                     <%= new Date(notification.created_at).toLocaleString('zh-CN') %>
                   </p>
                 </div>
                 <% if (notification.type === 'match_request' && notification.status === 'pending') { %>
-                  <div style="display: flex; gap: 8px; margin-left: 16px;">
-                    <form method="POST" action="/couple-match/accept/<%= notification.related_request_id %>" style="display: inline;">
+                  <div class="notification-actions">
+                    <form method="POST" action="/couple-match/accept/<%= notification.related_request_id %>" class="inline-form">
                       <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-                      <button type="submit" class="btn btn-primary" style="padding: 6px 12px; font-size: 14px;">同意</button>
+                      <button type="submit" class="btn btn-primary btn-small">同意</button>
                     </form>
-                    <form method="POST" action="/couple-match/reject/<%= notification.related_request_id %>" style="display: inline;">
+                    <form method="POST" action="/couple-match/reject/<%= notification.related_request_id %>" class="inline-form">
                       <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-                      <button type="submit" class="btn btn-secondary" style="padding: 6px 12px; font-size: 14px;">拒绝</button>
+                      <button type="submit" class="btn btn-secondary btn-small">拒绝</button>
                     </form>
                   </div>
                 <% } else if (notification.type === 'match_accepted' && notification.related_request_id) { %>
-                  <div style="margin-left: 16px;">
-                    <a href="/couple-match/result/<%= notification.related_request_id %>" class="btn btn-secondary" style="padding: 6px 12px; font-size: 14px;">查看结果</a>
+                  <div class="notification-action">
+                    <a href="/couple-match/result/<%= notification.related_request_id %>" class="btn btn-secondary btn-small">查看结果</a>
                   </div>
                 <% } %>
               </div>
@@ -48,7 +48,7 @@
           <% }); %>
         </div>
       <% } else { %>
-        <div style="text-align: center; padding: 40px 20px; color: var(--muted-foreground);">
+        <div class="notification-empty">
           <p>暂无通知</p>
         </div>
       <% } %>


### PR DESCRIPTION
## 变更内容
- 将 404 / error 页面内联布局样式改为复用 message-page/message-card 等 CSS class。
- 将 error 页的 history.back() 内联事件改为 public/js/history-back.js 外部脚本。
- 将 info-page 标题内联样式改为 info-title。
- 将 notifications 页列表、未读状态、按钮区域和空状态的内联样式移入 public/css/style.css。
- 更新 .version.json，纳入 style.css 和新增 history-back.js 的资源 hash。

## 验证
- node --check public/js/history-back.js
- git diff --check
- EJS render smoke：404、error、info-page、notifications
- npm test

Refs #125