### PR TITLE
重构：外置情侣匹配流程样式

### DIFF
--- a/.version.json
+++ b/.version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.2.0",
-  "generatedAt": "2026-05-04T03:34:25.916Z",
+  "generatedAt": "2026-05-04T04:02:12.663Z",
   "resources": {
     "css/account-pages.css": {
       "hash": "1b1d17ce",
@@ -11,8 +11,8 @@
       "version": "0.2.0-1fdea12d"
     },
     "css/style.css": {
-      "hash": "495ae758",
-      "version": "0.2.0-495ae758"
+      "hash": "f9edeff7",
+      "version": "0.2.0-f9edeff7"
     },
     "favicon.ico": {
       "hash": "5ecd6c3b",

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1057,6 +1057,174 @@ body {
   margin-top: 24px;
 }
 
+.match-flow-page {
+  max-width: 600px;
+  padding-top: 40px;
+}
+
+.match-flow-title {
+  margin-bottom: 24px;
+}
+
+.match-flow-copy {
+  color: var(--muted-foreground);
+  margin-bottom: 24px;
+}
+
+.match-flow-copy--compact {
+  margin-bottom: 20px;
+}
+
+.match-flow-note {
+  background: var(--accent);
+  border-radius: 8px;
+  color: var(--muted-foreground);
+  font-size: 0.9rem;
+  margin-bottom: 24px;
+  padding: 12px;
+}
+
+.match-flow-form {
+  margin-bottom: 32px;
+}
+
+.match-flow-form--compact {
+  margin-bottom: 12px;
+}
+
+.match-flow-row {
+  display: flex;
+  gap: 12px;
+}
+
+.match-flow-input {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  flex: 1;
+  padding: 12px;
+}
+
+.match-flow-full-action {
+  text-align: center;
+  width: 100%;
+}
+
+.match-flow-section-title {
+  margin: 32px 0 16px;
+}
+
+.match-flow-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.match-flow-list--loose {
+  gap: 12px;
+}
+
+.match-flow-card {
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  display: flex;
+  justify-content: space-between;
+  padding: 12px;
+}
+
+.match-flow-card--accepted {
+  background: var(--accent);
+  border: 0;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.match-flow-name {
+  margin: 0;
+}
+
+.match-flow-name--strong {
+  font-weight: 500;
+}
+
+.match-flow-meta {
+  color: var(--muted-foreground);
+  font-size: 12px;
+  margin: 4px 0 0;
+}
+
+.match-flow-status {
+  border: 1px solid transparent;
+  border-radius: 4px;
+  box-sizing: border-box;
+  font-size: 12px;
+  padding: 4px 8px;
+}
+
+.match-flow-status--pending {
+  background: var(--accent);
+  color: var(--accent-foreground);
+}
+
+.match-flow-status--accepted {
+  background: var(--success-bg);
+  border-color: var(--success-border);
+  color: var(--success-foreground);
+}
+
+.match-flow-status--rejected {
+  background: var(--error-bg);
+  border-color: var(--error-border);
+  color: var(--error-foreground);
+}
+
+.match-flow-pending-note {
+  color: var(--muted-foreground);
+  font-size: 12px;
+}
+
+.couple-result-score {
+  margin-bottom: 32px;
+  text-align: center;
+}
+
+.couple-result-target {
+  color: var(--muted-foreground);
+  margin-bottom: 8px;
+}
+
+.couple-result-total {
+  color: var(--primary);
+  font-size: 64px;
+  font-weight: bold;
+}
+
+.couple-result-info {
+  margin-bottom: 24px;
+}
+
+.couple-result-info h3 {
+  margin-bottom: 16px;
+}
+
+.couple-result-panel {
+  background: var(--accent);
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.couple-result-panel p {
+  margin: 0 0 8px;
+}
+
+.couple-result-panel p:last-child {
+  margin-bottom: 0;
+}
+
+.couple-result-actions {
+  text-align: center;
+}
+
 @media (max-width: 700px) {
   .match-card {
     flex-direction: column;
@@ -1083,6 +1251,12 @@ body {
 
   .match-week {
     min-width: 0;
+  }
+
+  .match-flow-row,
+  .match-flow-card {
+    align-items: stretch;
+    flex-direction: column;
   }
 }
 

--- a/views/confirm-match.ejs
+++ b/views/confirm-match.ejs
@@ -6,43 +6,43 @@
 <body>
   <%- include('partials/navbar') %>
 
-  <div class="container" style="max-width: 600px; padding-top: 40px;">
+  <div class="container match-flow-page">
     <div class="card">
-      <h2 style="margin-bottom: 24px;">💕 确认匹配</h2>
+      <h2 class="match-flow-title">💕 确认匹配</h2>
 
       <% if (typeof message !== 'undefined' && message && message !== '已取消本周匹配') { %>
-        <div class="alert alert-<%= messageType || 'info' %>" style="margin-bottom: 20px;">
+        <div class="alert alert-<%= messageType || 'info' %>">
           <%= message %>
         </div>
       <% } %>
 
       <% if (message === '已取消本周匹配') { %>
-        <div class="alert alert-success" style="margin-bottom: 20px;">
+        <div class="alert alert-success">
           <%= message %>
         </div>
-        <a href="/" class="btn" style="width: 100%; text-align: center;">返回首页</a>
+        <a href="/" class="btn match-flow-full-action">返回首页</a>
       <% } else if (user.weeklyMatchConfirmed) { %>
-        <p style="color: var(--muted-foreground); margin-bottom: 24px;">
+        <p class="match-flow-copy">
           你已确认参与本周匹配。
         </p>
-        <form method="POST" action="/confirm-match/cancel" style="margin-bottom: 12px;">
+        <form method="POST" action="/confirm-match/cancel" class="match-flow-form match-flow-form--compact">
           <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-          <button type="submit" class="btn btn-secondary" style="width: 100%;">
+          <button type="submit" class="btn btn-secondary match-flow-full-action">
             取消本周匹配
           </button>
         </form>
-        <a href="/" class="btn" style="width: 100%; text-align: center;">返回首页</a>
+        <a href="/" class="btn match-flow-full-action">返回首页</a>
       <% } else { %>
-        <p style="color: var(--muted-foreground); margin-bottom: 24px;">
+        <p class="match-flow-copy">
           点击下方按钮确认，你确定要参与本周匹配吗？确认后系统才会将你纳入本周的匹配候选池。
         </p>
-        <p style="font-size: 0.9rem; color: var(--muted-foreground); margin-bottom: 24px; padding: 12px; background: var(--accent); border-radius: 8px;">
+        <p class="match-flow-note">
           <strong>匹配成功后将向对方展示：</strong>学校邮箱、昵称、年级、性别、校区、LoveType、兴趣爱好和匹配评语。请确认可接受这些信息被对方查看。
         </p>
 
         <form method="POST" action="/confirm-match">
           <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-          <button type="submit" class="btn" style="width: 100%;">
+          <button type="submit" class="btn match-flow-full-action">
             确认参与本周匹配
           </button>
         </form>

--- a/views/couple-match.ejs
+++ b/views/couple-match.ejs
@@ -6,63 +6,63 @@
 <body>
   <%- include('partials/navbar') %>
 
-  <div class="container" style="max-width: 600px; padding-top: 40px;">
+  <div class="container match-flow-page">
     <div class="card">
-      <h2 style="margin-bottom: 24px;">情侣匹配</h2>
+      <h2 class="match-flow-title">情侣匹配</h2>
 
       <% if (typeof message !== 'undefined' && message) { %>
-        <div class="alert alert-<%= messageType || 'info' %>" style="margin-bottom: 20px;">
+        <div class="alert alert-<%= messageType || 'info' %>">
           <%= message %>
         </div>
       <% } %>
 
-      <p style="color: var(--muted-foreground); margin-bottom: 20px;">
+      <p class="match-flow-copy match-flow-copy--compact">
         输入对方邮箱，向TA发送情侣匹配申请。双方完成问卷后，在通知中心同意即可查看匹配结果。
       </p>
 
-      <form method="POST" action="/couple-match/request" style="margin-bottom: 32px;">
+      <form method="POST" action="/couple-match/request" class="match-flow-form">
         <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-        <div style="display: flex; gap: 12px;">
+        <div class="match-flow-row">
           <input
             type="email"
             name="email"
             placeholder="对方邮箱（@shu.edu.cn）"
             required
-            style="flex: 1; padding: 12px; border: 1px solid var(--border); border-radius: 6px;"
+            class="match-flow-input"
           >
           <button type="submit" class="btn btn-primary">发送申请</button>
         </div>
       </form>
 
       <% if (acceptedMatches && acceptedMatches.length > 0) { %>
-        <h3 style="margin-top: 32px; margin-bottom: 16px;">已匹配</h3>
-        <div style="display: flex; flex-direction: column; gap: 12px;">
+        <h3 class="match-flow-section-title">已匹配</h3>
+        <div class="match-flow-list match-flow-list--loose">
           <% acceptedMatches.forEach(function(match) { %>
-            <div style="padding: 16px; background: var(--accent); border-radius: 8px; display: flex; justify-content: space-between; align-items: center;">
+            <div class="match-flow-card match-flow-card--accepted">
               <div>
-                <p style="margin: 0; font-weight: 500;"><%= match.partner_nickname || match.partner_email %></p>
-                <p style="margin: 4px 0 0 0; font-size: 12px; color: var(--muted-foreground);">
+                <p class="match-flow-name match-flow-name--strong"><%= match.partner_nickname || match.partner_email %></p>
+                <p class="match-flow-meta">
                   匹配于 <%= new Date(match.matched_at).toLocaleDateString('zh-CN') %>
                 </p>
               </div>
-              <a href="/couple-match/result/<%= match.id %>" class="btn btn-secondary" style="padding: 8px 16px;">查看结果</a>
+              <a href="/couple-match/result/<%= match.id %>" class="btn btn-secondary btn-small">查看结果</a>
             </div>
           <% }); %>
         </div>
       <% } %>
 
       <% if (myRequests && myRequests.length > 0) { %>
-        <h3 style="margin-top: 32px; margin-bottom: 16px;">我发出的申请</h3>
-        <div style="display: flex; flex-direction: column; gap: 8px;">
+        <h3 class="match-flow-section-title">我发出的申请</h3>
+        <div class="match-flow-list">
           <% myRequests.forEach(function(req) { %>
-            <div style="padding: 12px; border: 1px solid var(--border); border-radius: 6px; display: flex; justify-content: space-between; align-items: center;">
+            <div class="match-flow-card">
               <div>
-                <p style="margin: 0;"><%= req.nickname || req.email %></p>
-                <p style="margin: 4px 0 0 0; font-size: 12px; color: var(--muted-foreground);">
+                <p class="match-flow-name"><%= req.nickname || req.email %></p>
+                <p class="match-flow-meta">
                   <%= new Date(req.created_at).toLocaleString('zh-CN') %>
                 </p>
               </div>
-                <span style="padding: 4px 8px; font-size: 12px; border-radius: 4px; border: 1px solid transparent; box-sizing: border-box; <% if (req.status === 'pending') { %>background: var(--accent); color: var(--accent-foreground);<% } else if (req.status === 'accepted') { %>background: var(--success-bg); color: var(--success-foreground); border-color: var(--success-border);<% } else if (req.status === 'rejected') { %>background: var(--error-bg); color: var(--error-foreground); border-color: var(--error-border);<% } %>">
+              <span class="match-flow-status match-flow-status--<%= req.status %>">
                 <% if (req.status === 'pending') { %>待回复<% } else if (req.status === 'accepted') { %>已同意<% } else if (req.status === 'rejected') { %>已拒绝<% } %>
               </span>
             </div>
@@ -71,20 +71,20 @@
       <% } %>
 
       <% if (receivedRequests && receivedRequests.length > 0) { %>
-        <h3 style="margin-top: 32px; margin-bottom: 16px;">收到的申请</h3>
-        <div style="display: flex; flex-direction: column; gap: 8px;">
+        <h3 class="match-flow-section-title">收到的申请</h3>
+        <div class="match-flow-list">
           <% receivedRequests.forEach(function(req) { %>
-            <div style="padding: 12px; border: 1px solid var(--border); border-radius: 6px; display: flex; justify-content: space-between; align-items: center;">
+            <div class="match-flow-card">
               <div>
-                <p style="margin: 0;"><%= req.nickname || req.email %></p>
-                <p style="margin: 4px 0 0 0; font-size: 12px; color: var(--muted-foreground);">
+                <p class="match-flow-name"><%= req.nickname || req.email %></p>
+                <p class="match-flow-meta">
                   <%= new Date(req.created_at).toLocaleString('zh-CN') %>
                 </p>
               </div>
               <% if (req.status === 'pending') { %>
-                <span style="color: var(--muted-foreground); font-size: 12px;">请在通知中心处理</span>
+                <span class="match-flow-pending-note">请在通知中心处理</span>
               <% } else { %>
-                <span style="padding: 4px 8px; font-size: 12px; border-radius: 4px; border: 1px solid transparent; box-sizing: border-box; <% if (req.status === 'accepted') { %>background: var(--success-bg); color: var(--success-foreground); border-color: var(--success-border);<% } else if (req.status === 'rejected') { %>background: var(--error-bg); color: var(--error-foreground); border-color: var(--error-border);<% } %>">
+                <span class="match-flow-status match-flow-status--<%= req.status %>">
                   <% if (req.status === 'accepted') { %>已同意<% } else if (req.status === 'rejected') { %>已拒绝<% } %>
                 </span>
               <% } %>

--- a/views/couple-result.ejs
+++ b/views/couple-result.ejs
@@ -9,19 +9,19 @@
 <body>
   <%- include('partials/navbar') %>
 
-  <div class="container" style="max-width: 600px; padding-top: 40px;">
+  <div class="container match-flow-page">
     <div class="card">
-      <h2 style="margin-bottom: 24px;">匹配结果</h2>
+      <h2 class="match-flow-title">匹配结果</h2>
 
       <% if (typeof message !== 'undefined' && message) { %>
-        <div class="alert alert-<%= messageType || 'info' %>" style="margin-bottom: 20px;">
+        <div class="alert alert-<%= messageType || 'info' %>">
           <%= message %>
         </div>
       <% } %>
 
-      <div style="text-align: center; margin-bottom: 32px;">
-        <p style="color: var(--muted-foreground); margin-bottom: 8px;">与 <strong><%= partner.nickname || partner.email %></strong> 的匹配度</p>
-        <div style="font-size: 64px; font-weight: bold; color: var(--primary);">
+      <div class="couple-result-score">
+        <p class="couple-result-target">与 <strong><%= partner.nickname || partner.email %></strong> 的匹配度</p>
+        <div class="couple-result-total">
           <%= matchResult ? Math.round(matchResult.total) : '--' %>分
         </div>
       </div>
@@ -38,18 +38,18 @@
       </div>
       <% } %>
 
-      <div style="margin-bottom: 24px;">
-        <h3 style="margin-bottom: 16px;">对方信息</h3>
-        <div style="padding: 16px; background: var(--accent); border-radius: 8px;">
-          <p style="margin: 0 0 8px 0;"><strong>昵称：</strong><%= partner.nickname || '未设置' %></p>
-          <% if (partner.my_grade) { %><p style="margin: 0 0 8px 0;"><strong>年级：</strong><%= partner.my_grade %></p><% } %>
-          <% if (partner.gender) { %><p style="margin: 0 0 8px 0;"><strong>性别：</strong><%= partner.gender %></p><% } %>
-          <% if (partner.campus) { %><p style="margin: 0 0 8px 0;"><strong>校区：</strong><%= partner.campus %></p><% } %>
-          <% if (partner.lovetype_code) { %><p style="margin: 0 0 8px 0;"><strong>恋爱类型：</strong><%= partner.lovetype_code %> - <%= partner.loveTypeProfile?.nickname || partner.loveTypeProfile?.title || '' %></p><% } %>
+      <div class="couple-result-info">
+        <h3>对方信息</h3>
+        <div class="couple-result-panel">
+          <p><strong>昵称：</strong><%= partner.nickname || '未设置' %></p>
+          <% if (partner.my_grade) { %><p><strong>年级：</strong><%= partner.my_grade %></p><% } %>
+          <% if (partner.gender) { %><p><strong>性别：</strong><%= partner.gender %></p><% } %>
+          <% if (partner.campus) { %><p><strong>校区：</strong><%= partner.campus %></p><% } %>
+          <% if (partner.lovetype_code) { %><p><strong>恋爱类型：</strong><%= partner.lovetype_code %> - <%= partner.loveTypeProfile?.nickname || partner.loveTypeProfile?.title || '' %></p><% } %>
         </div>
       </div>
 
-      <div style="text-align: center;">
+      <div class="couple-result-actions">
         <a href="/couple-match" class="btn btn-secondary">返回</a>
       </div>
     </div>


### PR DESCRIPTION
## 变更内容
- 将 confirm-match.ejs 的页面布局、提示文案和全宽按钮内联样式改为 CSS class。
- 将 couple-match.ejs 的申请表单、申请列表、状态徽章和卡片布局样式移入 public/css/style.css。
- 将 couple-result.ejs 的匹配分数、对方信息面板和返回按钮区样式移入 public/css/style.css。
- 更新 .version.json 中 style.css 的资源 hash。

## 验证
- git diff --check
- EJS render smoke：confirm-match、couple-match、couple-result 的主要分支
- npm test

Refs #125