### PR TITLE
重构：外置管理后台页面样式

### DIFF
--- a/.version.json
+++ b/.version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.2.0",
-  "generatedAt": "2026-05-04T04:02:12.663Z",
+  "generatedAt": "2026-05-04T04:09:43.028Z",
   "resources": {
     "css/account-pages.css": {
       "hash": "1b1d17ce",
@@ -11,8 +11,8 @@
       "version": "0.2.0-1fdea12d"
     },
     "css/style.css": {
-      "hash": "f9edeff7",
-      "version": "0.2.0-f9edeff7"
+      "hash": "958c586f",
+      "version": "0.2.0-958c586f"
     },
     "favicon.ico": {
       "hash": "5ecd6c3b",

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1296,6 +1296,94 @@ tr:hover td {
   background: var(--table-row-hover);
 }
 
+.admin-panel {
+  border-left: 4px solid var(--info);
+  border-radius: 8px;
+  margin-bottom: 20px;
+  padding: 15px;
+}
+
+.admin-panel--info {
+  background: var(--info-bg);
+  border-left-color: var(--info);
+}
+
+.admin-panel--warning {
+  background: var(--surface-soft);
+  border-left-color: var(--warning);
+}
+
+.admin-panel__title {
+  margin: 0 0 10px;
+}
+
+.admin-panel__title--info {
+  color: var(--info-foreground);
+}
+
+.admin-panel__title--warning {
+  color: var(--warning);
+}
+
+.admin-form {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.admin-label {
+  color: var(--muted-foreground);
+  font-size: 14px;
+}
+
+.admin-input {
+  background: var(--card);
+  border: 1px solid var(--input);
+  border-radius: 4px;
+  color: var(--foreground);
+  padding: 8px 12px;
+  width: 150px;
+}
+
+.admin-input--short {
+  width: 100px;
+}
+
+.admin-week-note {
+  color: var(--muted-foreground);
+  display: inline-block;
+  font-size: 12px;
+  margin-left: 15px;
+  margin-top: 10px;
+}
+
+.admin-checkbox-label {
+  align-items: center;
+  display: flex;
+  font-size: 14px;
+  gap: 5px;
+}
+
+.admin-checkbox-text {
+  color: var(--primary);
+}
+
+.admin-summary {
+  color: var(--muted-foreground);
+  margin-top: 20px;
+}
+
+.btn-warning {
+  background: var(--warning);
+  color: var(--warning-foreground);
+}
+
+.btn-warning:hover {
+  background: var(--warning);
+  filter: brightness(0.96);
+}
+
 .btn-danger {
   background: var(--error);
   color: white;

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -19,8 +19,9 @@
         <form action="/admin/match" method="POST" class="admin-form">
           <input type="hidden" name="csrfToken" value="<%= csrfToken %>">
           <div>
-            <label class="admin-label">确认密码：</label>
+            <label class="admin-label" for="admin-match-password">确认密码：</label>
             <input type="password" name="confirmPassword" placeholder="请输入您的密码" required
+                   id="admin-match-password"
                    class="admin-input">
           </div>
           <button type="submit" class="btn">🔄 执行匹配</button>
@@ -33,23 +34,26 @@
         <form action="/admin/match/rerun" method="POST" class="admin-form">
           <input type="hidden" name="csrfToken" value="<%= csrfToken %>">
           <div>
-            <label class="admin-label">目标年份：</label>
+            <label class="admin-label" for="admin-rerun-year">目标年份：</label>
             <input type="number" name="targetYear" placeholder="留空=当前年" min="2020" max="2100"
+                   id="admin-rerun-year"
                    class="admin-input admin-input--short">
           </div>
           <div>
-            <label class="admin-label">目标周数：</label>
+            <label class="admin-label" for="admin-rerun-week">目标周数：</label>
             <input type="number" name="targetWeek" placeholder="留空=当前周（0 起始）" min="0" max="53"
+                   id="admin-rerun-week"
                    class="admin-input admin-input--short">
           </div>
           <div>
-            <label class="admin-label">确认密码：</label>
+            <label class="admin-label" for="admin-rerun-password">确认密码：</label>
             <input type="password" name="confirmPassword" placeholder="请输入密码确认" required
+                   id="admin-rerun-password"
                    class="admin-input">
           </div>
           <div>
-            <label class="admin-checkbox-label">
-              <input type="checkbox" name="force" value="true">
+            <label class="admin-checkbox-label" for="admin-rerun-force">
+              <input type="checkbox" name="force" value="true" id="admin-rerun-force">
               <span class="admin-checkbox-text">强制重跑 (删除已有记录)</span>
             </label>
           </div>

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -14,46 +14,46 @@
     <div class="card">
       <h2>👥 用户管理</h2>
 
-      <div style="margin-bottom: 20px; padding: 15px; background: var(--info-bg); border-radius: 8px; border-left: 4px solid var(--info);">
-        <h4 style="margin: 0 0 10px 0; color: var(--info-foreground);">🔄 手动触发已截止匹配</h4>
-        <form action="/admin/match" method="POST" style="display: flex; gap: 10px; align-items: center; flex-wrap: wrap;">
+      <div class="admin-panel admin-panel--info">
+        <h4 class="admin-panel__title admin-panel__title--info">🔄 手动触发已截止匹配</h4>
+        <form action="/admin/match" method="POST" class="admin-form">
           <input type="hidden" name="csrfToken" value="<%= csrfToken %>">
           <div>
-            <label style="font-size: 14px; color: var(--muted-foreground);">确认密码：</label>
+            <label class="admin-label">确认密码：</label>
             <input type="password" name="confirmPassword" placeholder="请输入您的密码" required
-                   style="padding: 8px 12px; border: 1px solid var(--input); border-radius: 4px; width: 150px; background: var(--card); color: var(--foreground);">
+                   class="admin-input">
           </div>
           <button type="submit" class="btn">🔄 执行匹配</button>
         </form>
-        <span style="margin-left: 15px; color: var(--muted-foreground); font-size: 12px;">将执行 <%= year %> 年第 <%= weekNumber %> 周</span>
+        <span class="admin-week-note">将执行 <%= year %> 年第 <%= weekNumber %> 周</span>
       </div>
 
-      <div style="margin-bottom: 20px; padding: 15px; background: var(--surface-soft); border-radius: 8px; border-left: 4px solid var(--warning);">
-        <h4 style="margin: 0 0 10px 0; color: var(--warning);">🔧 补跑匹配</h4>
-        <form action="/admin/match/rerun" method="POST" style="display: flex; gap: 10px; align-items: center; flex-wrap: wrap;">
+      <div class="admin-panel admin-panel--warning">
+        <h4 class="admin-panel__title admin-panel__title--warning">🔧 补跑匹配</h4>
+        <form action="/admin/match/rerun" method="POST" class="admin-form">
           <input type="hidden" name="csrfToken" value="<%= csrfToken %>">
           <div>
-            <label style="font-size: 14px; color: var(--muted-foreground);">目标年份：</label>
+            <label class="admin-label">目标年份：</label>
             <input type="number" name="targetYear" placeholder="留空=当前年" min="2020" max="2100"
-                   style="padding: 8px 12px; border: 1px solid var(--input); border-radius: 4px; width: 100px; background: var(--card); color: var(--foreground);">
+                   class="admin-input admin-input--short">
           </div>
           <div>
-            <label style="font-size: 14px; color: var(--muted-foreground);">目标周数：</label>
+            <label class="admin-label">目标周数：</label>
             <input type="number" name="targetWeek" placeholder="留空=当前周（0 起始）" min="0" max="53"
-                   style="padding: 8px 12px; border: 1px solid var(--input); border-radius: 4px; width: 100px; background: var(--card); color: var(--foreground);">
+                   class="admin-input admin-input--short">
           </div>
           <div>
-            <label style="font-size: 14px; color: var(--muted-foreground);">确认密码：</label>
+            <label class="admin-label">确认密码：</label>
             <input type="password" name="confirmPassword" placeholder="请输入密码确认" required
-                   style="padding: 8px 12px; border: 1px solid var(--input); border-radius: 4px; width: 150px; background: var(--card); color: var(--foreground);">
+                   class="admin-input">
           </div>
           <div>
-            <label style="font-size: 14px; display: flex; align-items: center; gap: 5px;">
+            <label class="admin-checkbox-label">
               <input type="checkbox" name="force" value="true">
-              <span style="color: var(--primary);">强制重跑 (删除已有记录)</span>
+              <span class="admin-checkbox-text">强制重跑 (删除已有记录)</span>
             </label>
           </div>
-          <button type="submit" class="btn" style="background: var(--warning); color: var(--warning-foreground);">▶️ 执行补跑</button>
+          <button type="submit" class="btn btn-warning">▶️ 执行补跑</button>
         </form>
       </div>
 
@@ -82,7 +82,7 @@
         </tbody>
       </table>
 
-      <p style="margin-top: 20px; color: var(--muted-foreground);">
+      <p class="admin-summary">
         共 <%= users.length %> 位用户注册
       </p>
     </div>


### PR DESCRIPTION
## 变更内容
- 将 admin.ejs 中两个后台匹配操作面板的内联样式改为 admin-* CSS class。
- 将后台表单 label、input、checkbox、说明文案和统计文案样式移入 public/css/style.css。
- 新增 btn-warning 供补跑匹配按钮复用。
- 更新 .version.json 中 style.css 的资源 hash。

## 验证
- git diff --check
- EJS render smoke：admin.ejs
- npm test

Refs #125