### PR TITLE
重构：外置登录页邮箱指引交互

### DIFF
--- a/.version.json
+++ b/.version.json
@@ -1,10 +1,10 @@
 {
   "version": "0.2.0",
-  "generatedAt": "2026-05-04T04:09:43.028Z",
+  "generatedAt": "2026-05-04T04:24:27.145Z",
   "resources": {
     "css/account-pages.css": {
-      "hash": "1b1d17ce",
-      "version": "0.2.0-1b1d17ce"
+      "hash": "6044a9dc",
+      "version": "0.2.0-6044a9dc"
     },
     "css/dev-tools.css": {
       "hash": "1fdea12d",
@@ -55,8 +55,8 @@
       "version": "0.2.0-2b474f11"
     },
     "js/login-tabs.js": {
-      "hash": "0ce13845",
-      "version": "0.2.0-0ce13845"
+      "hash": "7fa8f43a",
+      "version": "0.2.0-7fa8f43a"
     },
     "js/theme.js": {
       "hash": "c1b29b66",

--- a/.version.json
+++ b/.version.json
@@ -1,10 +1,10 @@
 {
   "version": "0.2.0",
-  "generatedAt": "2026-05-04T04:24:27.145Z",
+  "generatedAt": "2026-05-04T14:16:36.533Z",
   "resources": {
     "css/account-pages.css": {
-      "hash": "6044a9dc",
-      "version": "0.2.0-6044a9dc"
+      "hash": "0caa3282",
+      "version": "0.2.0-0caa3282"
     },
     "css/dev-tools.css": {
       "hash": "1fdea12d",

--- a/public/css/account-pages.css
+++ b/public/css/account-pages.css
@@ -155,7 +155,7 @@
   font-size: 0.8rem;
   color: var(--primary);
   cursor: pointer;
-  font: inherit;
+  font-family: inherit;
   padding: 0;
   text-decoration: none;
 }

--- a/public/css/account-pages.css
+++ b/public/css/account-pages.css
@@ -150,8 +150,13 @@
 }
 
 .email-help-link {
+  border: 0;
+  background: transparent;
   font-size: 0.8rem;
   color: var(--primary);
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
   text-decoration: none;
 }
 

--- a/public/js/login-tabs.js
+++ b/public/js/login-tabs.js
@@ -37,10 +37,32 @@
     nextTab.focus();
   }
 
+  function setEmailGuideExpanded(toggle, expanded) {
+    var guideId = toggle.getAttribute('aria-controls');
+    var guide = guideId ? document.getElementById(guideId) : null;
+
+    if (!guide) return;
+
+    toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+    guide.toggleAttribute('hidden', !expanded);
+  }
+
   document.addEventListener('click', function(event) {
     var tab = event.target.closest('[data-login-method-target]');
-    if (!tab) return;
-    setLoginMethod(tab.getAttribute('data-login-method-target'));
+    var emailGuideToggle;
+
+    if (tab) {
+      setLoginMethod(tab.getAttribute('data-login-method-target'));
+      return;
+    }
+
+    emailGuideToggle = event.target.closest('[data-email-guide-toggle]');
+    if (!emailGuideToggle) return;
+
+    setEmailGuideExpanded(
+      emailGuideToggle,
+      emailGuideToggle.getAttribute('aria-expanded') !== 'true'
+    );
   });
 
   document.addEventListener('keydown', function(event) {
@@ -77,5 +99,9 @@
     if (activeTab) {
       setLoginMethod(activeTab.getAttribute('data-login-method-target'));
     }
+
+    document.querySelectorAll('[data-email-guide-toggle]').forEach(function(toggle) {
+      setEmailGuideExpanded(toggle, toggle.getAttribute('aria-expanded') === 'true');
+    });
   });
 })();

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -62,9 +62,11 @@
         </div>
         <div class="form-group email-with-help">
           <input class="form-control-center" type="email" name="email" placeholder="学校邮箱 (@shu.edu.cn)" value="<%= typeof email !== 'undefined' ? email : '' %>" autocomplete="email" aria-label="学校邮箱" autocapitalize="none" autocorrect="off" inputmode="email" required>
-          <a href="javascript:void(0)" class="email-help-link" onclick="toggleEmailGuide()">邮箱申请指引</a>
+          <button type="button" class="email-help-link" data-email-guide-toggle aria-controls="email-guide" aria-expanded="false">
+            邮箱申请指引
+          </button>
         </div>
-        <div id="email-guide" class="email-guide" style="display: none;">
+        <div id="email-guide" class="email-guide" hidden>
           <div class="email-guide-content">
             <p><strong>邮箱账号申请：</strong><a href="https://oauth.shu.edu.cn/" target="_blank">https://oauth.shu.edu.cn/</a></p>
             <p><strong>申请完成后登录上海大学邮件系统：</strong><a href="https://newmail.shu.edu.cn/coremail/" target="_blank">https://newmail.shu.edu.cn/coremail/</a></p>
@@ -100,15 +102,5 @@
   </div>
 
   <%- include('partials/site-footer') %>
-<script>
-function toggleEmailGuide() {
-  var guide = document.getElementById('email-guide');
-  if (guide.style.display === 'none') {
-    guide.style.display = 'block';
-  } else {
-    guide.style.display = 'none';
-  }
-}
-</script>
 </body>
 </html>


### PR DESCRIPTION
## 变更内容
- 将 login.ejs 的邮箱申请指引从 javascript:void(0) + onclick + 内联 script 改为 button + data 属性。
- 将邮箱指引显示状态改为 hidden / aria-expanded，由 login-tabs.js 统一控制。
- 调整 email-help-link 样式，使其作为 button 时保持原有链接视觉。
- 更新 .version.json 中 account-pages.css 和 login-tabs.js 的资源 hash。

## 验证
- node --check public/js/login-tabs.js
- git diff --check
- EJS render smoke：login/register 两种登录页状态
- npm test

Refs #125