### PR TITLE
重构：首页与布局样式外置

### DIFF
--- a/.version.json
+++ b/.version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.2.0",
-  "generatedAt": "2026-05-04T14:16:36.533Z",
+  "generatedAt": "2026-05-04T14:21:04.904Z",
   "resources": {
     "css/account-pages.css": {
       "hash": "0caa3282",
@@ -11,8 +11,8 @@
       "version": "0.2.0-1fdea12d"
     },
     "css/style.css": {
-      "hash": "958c586f",
-      "version": "0.2.0-958c586f"
+      "hash": "2b756a06",
+      "version": "0.2.0-2b756a06"
     },
     "favicon.ico": {
       "hash": "5ecd6c3b",

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -196,6 +196,10 @@ body {
   padding: 24px;
 }
 
+.layout-main {
+  margin-top: 30px;
+}
+
 /* ===== 导航栏 ===== */
 .navbar {
   border-bottom: 1px solid var(--border);
@@ -509,6 +513,11 @@ body {
   z-index: 1;
 }
 
+.hero .hero__status-note {
+  font-size: 0.9rem;
+  opacity: 0.7;
+}
+
 .hero .btn {
   background: var(--hero-button-bg);
   color: var(--hero-button-foreground);
@@ -521,6 +530,10 @@ body {
 .hero .btn:hover {
   background: var(--hero-button-hover);
   transform: translateY(-2px);
+}
+
+.hero .hero__cta {
+  margin-top: 20px;
 }
 
 /* ===== 倒计时 ===== */

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -14,7 +14,7 @@
     <div class="hero">
       <h1>心有所SHU</h1>
       <p class="subtitle">上大同学之间的互相认识，从这里开始</p>
-      <p style="opacity: 0.7; font-size: 0.9rem;">小范围内测中</p>
+      <p class="hero__status-note">小范围内测中</p>
       <% if (typeof nextMatchTime !== 'undefined' && typeof now !== 'undefined') { %>
         <% const timeLeft = nextMatchTime - now; %>
         <% const days = Math.floor(timeLeft / (1000 * 60 * 60 * 24)); %>
@@ -28,7 +28,7 @@
         </div>
       <% } %>
       <% if (typeof user === 'undefined' || !user) { %>
-        <a href="/login" class="btn btn-large" style="margin-top: 20px;">开始</a>
+        <a href="/login" class="btn btn-large hero__cta">开始</a>
       <% } %>
     </div>
 

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -22,7 +22,7 @@
     </div>
   </nav>
 
-  <div class="container" style="margin-top: 30px;">
+  <div class="container layout-main">
     <% if (typeof message !== 'undefined' && message) { %>
       <div class="alert alert-<%= messageType || 'info' %>"><%= message %></div>
     <% } %>


### PR DESCRIPTION
## 摘要
- 将首页 hero 中剩余的内联文字样式和 CTA 上边距迁移到 `public/css/style.css`
- 将 `layout.ejs` 主内容容器的内联上边距迁移为 `.layout-main`
- 更新 `css/style.css` 对应资源版本 hash

## 验证
- `Select-String` 检查 `views/index.ejs` / `views/layout.ejs` 已无 `style=` / `<script>` / `<style>` 命中
- `git diff --check`
- EJS render smoke：未登录首页、已登录首页、layout
- `npm test`

Refs #125