### PR TITLE
重构：外置资料页账户区样式

### DIFF
--- a/.version.json
+++ b/.version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.2.0",
-  "generatedAt": "2026-05-04T14:28:09.551Z",
+  "generatedAt": "2026-05-04T14:35:01.845Z",
   "resources": {
     "css/account-pages.css": {
       "hash": "0caa3282",
@@ -9,6 +9,10 @@
     "css/dev-tools.css": {
       "hash": "1fdea12d",
       "version": "0.2.0-1fdea12d"
+    },
+    "css/profile.css": {
+      "hash": "249693e2",
+      "version": "0.2.0-249693e2"
     },
     "css/style.css": {
       "hash": "2b756a06",

--- a/public/css/profile.css
+++ b/public/css/profile.css
@@ -1,0 +1,76 @@
+.profile-container {
+  max-width: 800px;
+}
+
+.profile-alert {
+  margin-bottom: 16px;
+}
+
+.profile-password-card {
+  background: var(--surface-soft);
+  padding: 20px;
+  margin-bottom: 20px;
+}
+
+.profile-password-title {
+  margin-bottom: 16px;
+}
+
+.profile-password-form {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.profile-password-label {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 0.9rem;
+  color: var(--foreground);
+}
+
+.profile-password-input {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid var(--input);
+  border-radius: 8px;
+  background: var(--card);
+  color: var(--foreground);
+}
+
+.profile-password-submit {
+  grid-column: 1 / -1;
+}
+
+.profile-password-help {
+  margin-top: 16px;
+  text-align: center;
+}
+
+.profile-forgot-link {
+  color: var(--primary);
+  font-size: 0.85rem;
+  text-decoration: underline;
+}
+
+.profile-result-title {
+  margin-bottom: 8px;
+}
+
+.profile-result-description {
+  color: var(--muted-foreground);
+  margin-bottom: 24px;
+}
+
+.profile-dev-fill {
+  margin-bottom: 20px;
+}
+
+.profile-result-actions {
+  margin-top: 20px;
+  text-align: center;
+}
+
+.profile-result-action {
+  display: inline-block;
+}

--- a/views/password.ejs
+++ b/views/password.ejs
@@ -23,7 +23,7 @@
         <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <div class="form-group form-group--compact">
           <label>当前密码</label>
-          <input type="password" name="currentPassword" placeholder="若未设置密码则留空">
+          <input type="password" name="currentPassword" placeholder="请输入当前密码">
         </div>
 
         <div class="form-group form-group--compact">

--- a/views/password.ejs
+++ b/views/password.ejs
@@ -22,18 +22,18 @@
       <form action="/settings/password" method="POST">
         <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <div class="form-group form-group--compact">
-          <label>当前密码</label>
-          <input type="password" name="currentPassword" placeholder="请输入当前密码">
+          <label for="settings-current-password">当前密码</label>
+          <input id="settings-current-password" type="password" name="currentPassword" placeholder="请输入当前密码">
         </div>
 
         <div class="form-group form-group--compact">
-          <label>新密码</label>
-          <input type="password" name="newPassword" placeholder="至少6位" minlength="6">
+          <label for="settings-new-password">新密码</label>
+          <input id="settings-new-password" type="password" name="newPassword" placeholder="至少6位" minlength="6">
         </div>
 
         <div class="form-group form-group--final">
-          <label>确认新密码</label>
-          <input type="password" name="confirmPassword" placeholder="再次输入新密码">
+          <label for="settings-confirm-password">确认新密码</label>
+          <input id="settings-confirm-password" type="password" name="confirmPassword" placeholder="再次输入新密码">
         </div>
 
         <button type="submit" class="btn btn-secondary">修改密码</button>

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -549,10 +549,11 @@
         </div>
       <% } %>
 
-      <form action="/profile/password" method="POST" class="profile-password-form">
+      <form action="/settings/password" method="POST" class="profile-password-form">
+        <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <div>
           <label for="profile-current-password" class="profile-password-label">当前密码</label>
-          <input id="profile-current-password" type="password" name="currentPassword" placeholder="若未设置密码则留空" class="profile-password-input">
+          <input id="profile-current-password" type="password" name="currentPassword" placeholder="请输入当前密码" class="profile-password-input">
         </div>
         <div></div>
         <div>

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>填写问卷 - 心有所SHU</title>
   <link rel="stylesheet" href="/css/style.css?v=0.2.0">
+  <link rel="stylesheet" href="/css/profile.css?v=0.2.0">
     <%- include('partials/head-icons') %>
   <% if (typeof isDev !== 'undefined' && isDev) { %>
   <link rel="stylesheet" href="/css/dev-tools.css?v=0.2.0">
@@ -531,44 +532,44 @@
 <body class="profile-page">
   <%- include('partials/navbar') %>
 
-  <div class="container" style="max-width: 800px;">
+  <div class="container profile-container">
     <% if (typeof message !== 'undefined' && message) { %>
-      <div class="alert alert-<%= messageType || 'info' %>" style="margin-bottom: 16px;">
+      <div class="alert alert-<%= messageType || 'info' %> profile-alert">
         <%= message %>
       </div>
     <% } %>
 
     <% if (typeof showPassword !== 'undefined' && showPassword) { %>
-    <div class="card" style="background: var(--surface-soft); padding: 20px; margin-bottom: 20px;">
-      <h3 style="margin-bottom: 16px;">🔐 修改密码</h3>
+    <div class="card profile-password-card">
+      <h3 class="profile-password-title">🔐 修改密码</h3>
 
       <% if (typeof passwordMessage !== 'undefined' && passwordMessage) { %>
-        <div class="alert alert-<%= passwordMessageType || 'info' %>" style="margin-bottom: 16px;">
+        <div class="alert alert-<%= passwordMessageType || 'info' %> profile-alert">
           <%= passwordMessage %>
         </div>
       <% } %>
 
-      <form action="/profile/password" method="POST" style="display: grid; grid-template-columns: 1fr 1fr; gap: 12px;">
+      <form action="/profile/password" method="POST" class="profile-password-form">
         <div>
-          <label style="display: block; margin-bottom: 6px; font-size: 0.9rem; color: var(--foreground);">当前密码</label>
-          <input type="password" name="currentPassword" placeholder="若未设置密码则留空" style="width: 100%; padding: 10px; border: 1px solid var(--input); border-radius: 8px; background: var(--card); color: var(--foreground);">
+          <label for="profile-current-password" class="profile-password-label">当前密码</label>
+          <input id="profile-current-password" type="password" name="currentPassword" placeholder="若未设置密码则留空" class="profile-password-input">
         </div>
         <div></div>
         <div>
-          <label style="display: block; margin-bottom: 6px; font-size: 0.9rem; color: var(--foreground);">新密码</label>
-          <input type="password" name="newPassword" placeholder="至少6位" minlength="6" style="width: 100%; padding: 10px; border: 1px solid var(--input); border-radius: 8px; background: var(--card); color: var(--foreground);">
+          <label for="profile-new-password" class="profile-password-label">新密码</label>
+          <input id="profile-new-password" type="password" name="newPassword" placeholder="至少6位" minlength="6" class="profile-password-input">
         </div>
         <div>
-          <label style="display: block; margin-bottom: 6px; font-size: 0.9rem; color: var(--foreground);">确认新密码</label>
-          <input type="password" name="confirmPassword" placeholder="再次输入新密码" style="width: 100%; padding: 10px; border: 1px solid var(--input); border-radius: 8px; background: var(--card); color: var(--foreground);">
+          <label for="profile-confirm-password" class="profile-password-label">确认新密码</label>
+          <input id="profile-confirm-password" type="password" name="confirmPassword" placeholder="再次输入新密码" class="profile-password-input">
         </div>
-        <div style="grid-column: 1 / -1;">
+        <div class="profile-password-submit">
           <button type="submit" class="btn btn-secondary">修改密码</button>
         </div>
       </form>
 
-      <div style="margin-top: 16px; text-align: center;">
-        <a href="/forgot" style="color: var(--primary); font-size: 0.85rem; text-decoration: underline;">忘记密码</a>
+      <div class="profile-password-help">
+        <a href="/forgot" class="profile-forgot-link">忘记密码</a>
       </div>
     </div>
     <% } %>
@@ -576,11 +577,11 @@
     <% if (!showPassword) { %>
     <!-- 恋爱类型结果 -->
     <div class="card">
-      <h2 style="margin-bottom: 8px;">📝 恋爱人格结果</h2>
-      <p style="color: var(--muted-foreground); margin-bottom: 24px;">通过恋爱类型测试，发现您真正的浪漫人格</p>
+      <h2 class="profile-result-title">📝 恋爱人格结果</h2>
+      <p class="profile-result-description">通过恋爱类型测试，发现您真正的浪漫人格</p>
 
     <% if (typeof isDev !== 'undefined' && isDev) { %>
-        <button type="button" id="devFillBtn" class="btn btn-secondary" style="margin-bottom: 20px;">🔧 一键填写（测试）</button>
+        <button type="button" id="devFillBtn" class="btn btn-secondary profile-dev-fill">🔧 一键填写（测试）</button>
     <% } %>
 
     <% if (lovetypeResult) { %>
@@ -662,8 +663,8 @@
         </div>
       <% } %>
 
-      <div style="margin-top: 20px; text-align: center;">
-        <a href="/profile?edit=1" class="btn btn-secondary" style="display: inline-block;">✏️ 修改问卷</a>
+      <div class="profile-result-actions">
+        <a href="/profile?edit=1" class="btn btn-secondary profile-result-action">✏️ 修改问卷</a>
       </div>
     </div>
   <% } %>


### PR DESCRIPTION
## 摘要
- 新增 `public/css/profile.css`，承接资料页顶部账户/改密/恋爱人格结果入口区域样式
- 移除 `profile.ejs` 顶部区域的内联 `style=`，改用语义化 class
- 为改密表单的三个 label 补充 `for/id` 关联
- 将 `profile.css` 加入 `.version.json` 资源清单

## 验证
- `Select-String` / 正则计数确认 `profile.ejs` 的 `style=` 从 25 降到 5，剩余项都在问卷主体，未纳入本轮
- profile EJS render smoke：改密页面、恋爱人格结果页面
- `git diff --check`
- `npm test`

Refs #125