### PR TITLE
重构：移除下拉菜单 hover 打开规则

### DIFF
--- a/.version.json
+++ b/.version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.2.0",
-  "generatedAt": "2026-05-05T03:19:37.308Z",
+  "generatedAt": "2026-05-05T03:24:23.472Z",
   "resources": {
     "css/account-pages.css": {
       "hash": "0caa3282",
@@ -15,8 +15,8 @@
       "version": "0.2.0-cd7871cc"
     },
     "css/style.css": {
-      "hash": "2b756a06",
-      "version": "0.2.0-2b756a06"
+      "hash": "e8c5ff05",
+      "version": "0.2.0-e8c5ff05"
     },
     "favicon.ico": {
       "hash": "5ecd6c3b",

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1796,17 +1796,6 @@ tr:hover td {
   box-sizing: border-box;
 }
 
-/* 伪元素填充间隙，保持 hover 连续性 */
-.dropdown-menu::before {
-  content: '';
-  position: absolute;
-  top: -4px;
-  left: 0;
-  right: 0;
-  height: 4px;
-  pointer-events: auto;
-}
-
 .dropdown-menu a {
   display: block;
   padding: 10px 16px;
@@ -1818,12 +1807,6 @@ tr:hover td {
 
 .dropdown-menu a:hover {
   background: var(--muted);
-}
-
-@media (hover: hover) and (pointer: fine) {
-  .dropdown:hover .dropdown-menu {
-    display: block;
-  }
 }
 
 .dropdown-menu.show {


### PR DESCRIPTION
﻿## 变更内容
- 移除旧 `.dropdown:hover .dropdown-menu` 的 hover 打开规则
- 删除仅服务于 hover 连续性的 `.dropdown-menu::before` 补缝伪元素
- 保留 `.dropdown-menu.show` 作为下拉菜单唯一显示状态，避免 hover/click 双轨并存
- 更新 `.version.json` 中 `css/style.css` 的资源哈希

## 验证
- 确认 `style.css` 中已无 `dropdown:hover` / `hover: hover` / `dropdown-menu::before`
- `git diff --check`
- 首页 EJS render smoke test
- `npm test`

Refs #125
