### PR TITLE
增强：添加认证表单即时校验

### DIFF
--- a/.version.json
+++ b/.version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.2.0",
-  "generatedAt": "2026-05-05T11:58:05.073Z",
+  "generatedAt": "2026-05-05T12:06:46.363Z",
   "resources": {
     "css/account-pages.css": {
       "hash": "643fdd11",
@@ -75,8 +75,8 @@
       "version": "0.2.0-bb887713"
     },
     "js/auth-validation.js": {
-      "hash": "22953945",
-      "version": "0.2.0-22953945"
+      "hash": "741dd6b3",
+      "version": "0.2.0-741dd6b3"
     }
   }
 }

--- a/.version.json
+++ b/.version.json
@@ -1,10 +1,10 @@
 {
   "version": "0.2.0",
-  "generatedAt": "2026-05-05T03:24:23.472Z",
+  "generatedAt": "2026-05-05T11:58:05.073Z",
   "resources": {
     "css/account-pages.css": {
-      "hash": "0caa3282",
-      "version": "0.2.0-0caa3282"
+      "hash": "643fdd11",
+      "version": "0.2.0-643fdd11"
     },
     "css/dev-tools.css": {
       "hash": "1fdea12d",
@@ -73,6 +73,10 @@
     "js/profile.js": {
       "hash": "bb887713",
       "version": "0.2.0-bb887713"
+    },
+    "js/auth-validation.js": {
+      "hash": "22953945",
+      "version": "0.2.0-22953945"
     }
   }
 }

--- a/public/css/account-pages.css
+++ b/public/css/account-pages.css
@@ -109,6 +109,19 @@
   text-align: center;
 }
 
+.form-group--invalid input {
+  border-color: var(--error-border);
+  box-shadow: 0 0 0 3px rgba(232, 90, 90, 0.15);
+}
+
+.auth-field-error {
+  margin: 6px 0 0;
+  color: var(--error-foreground);
+  font-size: 0.78rem;
+  line-height: 1.4;
+  text-align: center;
+}
+
 .btn-full {
   width: 100%;
 }

--- a/public/js/auth-validation.js
+++ b/public/js/auth-validation.js
@@ -118,6 +118,8 @@
     var submitted = false;
     var fields = Array.prototype.slice.call(form.querySelectorAll('[data-auth-field]'));
 
+    form.noValidate = true;
+
     fields.forEach(function(field) {
       var validate = function() {
         var message = validateField(form, field);

--- a/public/js/auth-validation.js
+++ b/public/js/auth-validation.js
@@ -1,0 +1,160 @@
+(function() {
+  var SHU_EMAIL_RE = /^[a-z0-9._%+-]+@shu\.edu\.cn$/;
+  var EMAIL_RE = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+  var nextErrorId = 0;
+
+  function getFieldLabel(field) {
+    return field.getAttribute('aria-label') || field.getAttribute('placeholder') || field.name || '该字段';
+  }
+
+  function ensureErrorElement(field) {
+    var group = field.closest('.form-group') || field.parentElement;
+    var id = field.id || field.getAttribute('data-auth-error-id');
+    var errorId = id + '-error';
+    var error = document.getElementById(errorId);
+    var describedBy;
+
+    if (!id) {
+      nextErrorId += 1;
+      id = 'auth-field-' + nextErrorId;
+      field.setAttribute('data-auth-error-id', id);
+      errorId = id + '-error';
+      error = null;
+    }
+
+    if (!error) {
+      error = document.createElement('p');
+      error.id = errorId;
+      error.className = 'auth-field-error';
+      error.setAttribute('role', 'alert');
+      error.hidden = true;
+      if (group) {
+        group.appendChild(error);
+      } else {
+        field.insertAdjacentElement('afterend', error);
+      }
+    }
+
+    describedBy = field.getAttribute('aria-describedby') || '';
+    if (!describedBy.split(/\s+/).includes(errorId)) {
+      field.setAttribute('aria-describedby', (describedBy + ' ' + errorId).trim());
+    }
+
+    return error;
+  }
+
+  function getMatchedField(form, field) {
+    var targetName = field.getAttribute('data-auth-match');
+    if (!targetName) return null;
+    return form.querySelector('[name="' + targetName + '"]');
+  }
+
+  function validateField(form, field) {
+    var type = field.getAttribute('data-auth-field');
+    var value = type === 'password' || type === 'login-password' || type === 'confirm-password'
+      ? field.value
+      : field.value.trim();
+    var label = getFieldLabel(field);
+    var matchedField;
+
+    if (!type) return '';
+
+    if (!value) {
+      return '请填写' + label;
+    }
+
+    if (type === 'email' && !EMAIL_RE.test(value)) {
+      return '请输入有效的邮箱地址';
+    }
+
+    if (type === 'shu-email' && !SHU_EMAIL_RE.test(value.toLowerCase())) {
+      return '请输入 @shu.edu.cn 结尾的学校邮箱';
+    }
+
+    if (type === 'password' && value.length < 6) {
+      return '密码长度至少6位';
+    }
+
+    if (type === 'confirm-password') {
+      matchedField = getMatchedField(form, field);
+      if (matchedField && value !== matchedField.value) {
+        return '两次输入的密码不一致';
+      }
+    }
+
+    return '';
+  }
+
+  function setFieldError(field, message) {
+    var group = field.closest('.form-group');
+    var error = ensureErrorElement(field);
+
+    field.setAttribute('aria-invalid', message ? 'true' : 'false');
+    field.setCustomValidity(message);
+    if (group) {
+      group.classList.toggle('form-group--invalid', Boolean(message));
+    }
+
+    error.textContent = message;
+    error.hidden = !message;
+  }
+
+  function validateForm(form) {
+    var firstInvalid = null;
+    var fields = Array.prototype.slice.call(form.querySelectorAll('[data-auth-field]'));
+
+    fields.forEach(function(field) {
+      var message = validateField(form, field);
+      setFieldError(field, message);
+      if (message && !firstInvalid) {
+        firstInvalid = field;
+      }
+    });
+
+    return firstInvalid;
+  }
+
+  function bindForm(form) {
+    var submitted = false;
+    var fields = Array.prototype.slice.call(form.querySelectorAll('[data-auth-field]'));
+
+    fields.forEach(function(field) {
+      var validate = function() {
+        var message = validateField(form, field);
+        setFieldError(field, message);
+
+        if (field.getAttribute('data-auth-field') === 'password') {
+          form.querySelectorAll('[data-auth-field="confirm-password"]').forEach(function(confirmField) {
+            if (confirmField.value || submitted) {
+              setFieldError(confirmField, validateField(form, confirmField));
+            }
+          });
+        }
+      };
+
+      ensureErrorElement(field);
+      field.addEventListener('blur', function() {
+        validate();
+      });
+      field.addEventListener('input', function() {
+        if (submitted || field.getAttribute('aria-invalid') === 'true') {
+          validate();
+        }
+      });
+    });
+
+    form.addEventListener('submit', function(event) {
+      var firstInvalid;
+      submitted = true;
+      firstInvalid = validateForm(form);
+      if (!firstInvalid) return;
+
+      event.preventDefault();
+      firstInvalid.focus();
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('form[data-auth-validation]').forEach(bindForm);
+  });
+})();

--- a/views/forgot.ejs
+++ b/views/forgot.ejs
@@ -28,7 +28,7 @@
         </div>
       <% } %>
 
-      <form action="/forgot" method="POST" data-auth-validation novalidate>
+      <form action="/forgot" method="POST" data-auth-validation>
         <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <div class="form-group">
           <input class="form-control-center" type="email" name="email" placeholder="学校邮箱 (@shu.edu.cn)" value="<%= typeof email !== 'undefined' ? email : '' %>" autocomplete="username" aria-label="学校邮箱" autocapitalize="none" autocorrect="off" inputmode="email" data-auth-field="shu-email" required>

--- a/views/forgot.ejs
+++ b/views/forgot.ejs
@@ -3,7 +3,8 @@
 <head>
   <%- include('partials/document-head', {
     pageTitle: typeof title !== 'undefined' ? title : '忘记密码',
-    accountPage: true
+    accountPage: true,
+    authValidationScript: true
   }) %>
 </head>
 <body>
@@ -27,10 +28,10 @@
         </div>
       <% } %>
 
-      <form action="/forgot" method="POST">
+      <form action="/forgot" method="POST" data-auth-validation novalidate>
         <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <div class="form-group">
-          <input class="form-control-center" type="email" name="email" placeholder="学校邮箱 (@shu.edu.cn)" value="<%= typeof email !== 'undefined' ? email : '' %>" autocomplete="username" aria-label="学校邮箱" autocapitalize="none" autocorrect="off" inputmode="email" required>
+          <input class="form-control-center" type="email" name="email" placeholder="学校邮箱 (@shu.edu.cn)" value="<%= typeof email !== 'undefined' ? email : '' %>" autocomplete="username" aria-label="学校邮箱" autocapitalize="none" autocorrect="off" inputmode="email" data-auth-field="shu-email" required>
         </div>
         <button type="submit" class="btn btn-full">发送重置链接</button>
       </form>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -56,7 +56,7 @@
       </div>
 
       <!-- 注册表单 -->
-      <form action="/register" method="POST" id="login-panel-register" class="login-form <%= (loginMethod === 'register') ? 'active' : '' %>" data-login-method-panel="register" data-auth-validation novalidate role="tabpanel" aria-labelledby="login-tab-register" aria-hidden="<%= (loginMethod === 'register') ? 'false' : 'true' %>" <%= (loginMethod === 'register') ? '' : 'hidden' %>>
+      <form action="/register" method="POST" id="login-panel-register" class="login-form <%= (loginMethod === 'register') ? 'active' : '' %>" data-login-method-panel="register" data-auth-validation role="tabpanel" aria-labelledby="login-tab-register" aria-hidden="<%= (loginMethod === 'register') ? 'false' : 'true' %>" <%= (loginMethod === 'register') ? '' : 'hidden' %>>
         <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <div class="form-group">
           <input class="form-control-center" type="text" name="nickname" placeholder="昵称" value="<%= typeof nickname !== 'undefined' ? nickname : '' %>" autocomplete="nickname" aria-label="昵称" data-auth-field="nickname" required>
@@ -84,7 +84,7 @@
       </form>
 
       <!-- 登录表单 -->
-      <form action="/login" method="POST" id="login-panel-login" class="login-form <%= (loginMethod === 'login') ? 'active' : '' %>" data-login-method-panel="login" data-auth-validation novalidate role="tabpanel" aria-labelledby="login-tab-login" aria-hidden="<%= (loginMethod === 'login') ? 'false' : 'true' %>" <%= (loginMethod === 'login') ? '' : 'hidden' %>>
+      <form action="/login" method="POST" id="login-panel-login" class="login-form <%= (loginMethod === 'login') ? 'active' : '' %>" data-login-method-panel="login" data-auth-validation role="tabpanel" aria-labelledby="login-tab-login" aria-hidden="<%= (loginMethod === 'login') ? 'false' : 'true' %>" <%= (loginMethod === 'login') ? '' : 'hidden' %>>
         <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <div class="form-group">
           <input class="form-control-center" type="email" name="email" placeholder="你的学校邮箱" value="<%= typeof email !== 'undefined' ? email : '' %>" autocomplete="username" aria-label="登录邮箱" autocapitalize="none" autocorrect="off" inputmode="email" data-auth-field="email" required>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -4,7 +4,8 @@
   <%- include('partials/document-head', {
     pageTitle: '登录',
     accountPage: true,
-    loginTabsScript: true
+    loginTabsScript: true,
+    authValidationScript: true
   }) %>
 </head>
 <body>
@@ -55,13 +56,13 @@
       </div>
 
       <!-- 注册表单 -->
-      <form action="/register" method="POST" id="login-panel-register" class="login-form <%= (loginMethod === 'register') ? 'active' : '' %>" data-login-method-panel="register" role="tabpanel" aria-labelledby="login-tab-register" aria-hidden="<%= (loginMethod === 'register') ? 'false' : 'true' %>" <%= (loginMethod === 'register') ? '' : 'hidden' %>>
+      <form action="/register" method="POST" id="login-panel-register" class="login-form <%= (loginMethod === 'register') ? 'active' : '' %>" data-login-method-panel="register" data-auth-validation novalidate role="tabpanel" aria-labelledby="login-tab-register" aria-hidden="<%= (loginMethod === 'register') ? 'false' : 'true' %>" <%= (loginMethod === 'register') ? '' : 'hidden' %>>
         <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <div class="form-group">
-          <input class="form-control-center" type="text" name="nickname" placeholder="昵称" value="<%= typeof nickname !== 'undefined' ? nickname : '' %>" autocomplete="nickname" aria-label="昵称" required>
+          <input class="form-control-center" type="text" name="nickname" placeholder="昵称" value="<%= typeof nickname !== 'undefined' ? nickname : '' %>" autocomplete="nickname" aria-label="昵称" data-auth-field="nickname" required>
         </div>
         <div class="form-group email-with-help">
-          <input class="form-control-center" type="email" name="email" placeholder="学校邮箱 (@shu.edu.cn)" value="<%= typeof email !== 'undefined' ? email : '' %>" autocomplete="email" aria-label="学校邮箱" autocapitalize="none" autocorrect="off" inputmode="email" required>
+          <input class="form-control-center" type="email" name="email" placeholder="学校邮箱 (@shu.edu.cn)" value="<%= typeof email !== 'undefined' ? email : '' %>" autocomplete="email" aria-label="学校邮箱" autocapitalize="none" autocorrect="off" inputmode="email" data-auth-field="shu-email" required>
           <button type="button" class="email-help-link" data-email-guide-toggle aria-controls="email-guide" aria-expanded="false">
             邮箱申请指引
           </button>
@@ -74,22 +75,22 @@
           </div>
         </div>
         <div class="form-group">
-          <input class="form-control-center" type="password" name="password" placeholder="设置密码（至少6位）" autocomplete="new-password" aria-label="设置密码" required minlength="6">
+          <input class="form-control-center" type="password" name="password" placeholder="设置密码（至少6位）" autocomplete="new-password" aria-label="设置密码" data-auth-field="password" required minlength="6">
         </div>
         <div class="form-group">
-          <input class="form-control-center" type="password" name="confirmPassword" placeholder="再次输入密码确认" autocomplete="new-password" aria-label="确认密码" required minlength="6">
+          <input class="form-control-center" type="password" name="confirmPassword" placeholder="再次输入密码确认" autocomplete="new-password" aria-label="确认密码" data-auth-field="confirm-password" data-auth-match="password" required minlength="6">
         </div>
         <button type="submit" class="btn btn-full">注册</button>
       </form>
 
       <!-- 登录表单 -->
-      <form action="/login" method="POST" id="login-panel-login" class="login-form <%= (loginMethod === 'login') ? 'active' : '' %>" data-login-method-panel="login" role="tabpanel" aria-labelledby="login-tab-login" aria-hidden="<%= (loginMethod === 'login') ? 'false' : 'true' %>" <%= (loginMethod === 'login') ? '' : 'hidden' %>>
+      <form action="/login" method="POST" id="login-panel-login" class="login-form <%= (loginMethod === 'login') ? 'active' : '' %>" data-login-method-panel="login" data-auth-validation novalidate role="tabpanel" aria-labelledby="login-tab-login" aria-hidden="<%= (loginMethod === 'login') ? 'false' : 'true' %>" <%= (loginMethod === 'login') ? '' : 'hidden' %>>
         <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <div class="form-group">
-          <input class="form-control-center" type="email" name="email" placeholder="你的学校邮箱" value="<%= typeof email !== 'undefined' ? email : '' %>" autocomplete="username" aria-label="登录邮箱" autocapitalize="none" autocorrect="off" inputmode="email" required>
+          <input class="form-control-center" type="email" name="email" placeholder="你的学校邮箱" value="<%= typeof email !== 'undefined' ? email : '' %>" autocomplete="username" aria-label="登录邮箱" autocapitalize="none" autocorrect="off" inputmode="email" data-auth-field="email" required>
         </div>
         <div class="form-group">
-          <input class="form-control-center" type="password" name="password" placeholder="登录密码" autocomplete="current-password" aria-label="登录密码" required>
+          <input class="form-control-center" type="password" name="password" placeholder="登录密码" autocomplete="current-password" aria-label="登录密码" data-auth-field="login-password" required>
         </div>
         <button type="submit" class="btn btn-full">登录</button>
         <a href="/forgot" class="forgot-password">忘记密码？</a>

--- a/views/partials/document-head.ejs
+++ b/views/partials/document-head.ejs
@@ -6,6 +6,7 @@
   const resolvedDocumentTitle = providedFullTitle || (resolvedTitle ? `${resolvedTitle} - 心有所SHU` : '心有所SHU');
   const includeAccountStyles = typeof accountPage !== 'undefined' && accountPage;
   const includeLoginTabsScript = typeof loginTabsScript !== 'undefined' && loginTabsScript;
+  const includeAuthValidationScript = typeof authValidationScript !== 'undefined' && authValidationScript;
   const includeDevToolsStyles = typeof devToolsStyles !== 'undefined' && devToolsStyles && typeof isDev !== 'undefined' && isDev;
 %>
 <meta charset="UTF-8">
@@ -21,4 +22,7 @@
 <% } %>
 <% if (includeLoginTabsScript) { %>
   <script src="/js/login-tabs.js?v=0.2.0" defer></script>
+<% } %>
+<% if (includeAuthValidationScript) { %>
+  <script src="/js/auth-validation.js?v=0.2.0" defer></script>
 <% } %>

--- a/views/reset.ejs
+++ b/views/reset.ejs
@@ -3,7 +3,8 @@
 <head>
   <%- include('partials/document-head', {
     pageTitle: typeof title !== 'undefined' ? title : '重置密码',
-    accountPage: true
+    accountPage: true,
+    authValidationScript: true
   }) %>
 </head>
 <body>
@@ -22,13 +23,13 @@
         </div>
       <% } %>
 
-      <form action="/reset/<%= code %>" method="POST">
+      <form action="/reset/<%= code %>" method="POST" data-auth-validation novalidate>
         <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <div class="form-group">
-          <input class="form-control-center" type="password" name="password" placeholder="新密码（至少6位）" autocomplete="new-password" aria-label="新密码" required minlength="6">
+          <input class="form-control-center" type="password" name="password" placeholder="新密码（至少6位）" autocomplete="new-password" aria-label="新密码" data-auth-field="password" required minlength="6">
         </div>
         <div class="form-group">
-          <input class="form-control-center" type="password" name="confirmPassword" placeholder="确认新密码" autocomplete="new-password" aria-label="确认新密码" required>
+          <input class="form-control-center" type="password" name="confirmPassword" placeholder="确认新密码" autocomplete="new-password" aria-label="确认新密码" data-auth-field="confirm-password" data-auth-match="password" required>
         </div>
         <button type="submit" class="btn btn-full">重置密码</button>
       </form>

--- a/views/reset.ejs
+++ b/views/reset.ejs
@@ -23,7 +23,7 @@
         </div>
       <% } %>
 
-      <form action="/reset/<%= code %>" method="POST" data-auth-validation novalidate>
+      <form action="/reset/<%= code %>" method="POST" data-auth-validation>
         <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <div class="form-group">
           <input class="form-control-center" type="password" name="password" placeholder="新密码（至少6位）" autocomplete="new-password" aria-label="新密码" data-auth-field="password" required minlength="6">


### PR DESCRIPTION
﻿## 变更内容
- 新增 `public/js/auth-validation.js`，提供认证表单即时校验和可访问性错误提示。
- 登录/注册、忘记密码、重置密码表单接入 `data-auth-validation`。
- 支持邮箱格式、`@shu.edu.cn` 邮箱、密码长度、确认密码一致性和必填项提示。
- 为错误状态补充 `aria-invalid`、`aria-describedby`、`role="alert"` 与视觉样式。
- 保留后端校验作为最终可信来源，不修改业务规则。

## 验证
- `node --check public/js/auth-validation.js`
- 登录/注册/忘记密码/重置密码 EJS render smoke test
- `npm test`
- `git diff --cached --check`

Refs #172
