### PR TITLE
增强：添加设置表单即时校验

### DIFF
--- a/.version.json
+++ b/.version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.2.0",
-  "generatedAt": "2026-05-05T12:14:55.945Z",
+  "generatedAt": "2026-05-05T12:35:07.287Z",
   "resources": {
     "css/account-pages.css": {
       "hash": "643fdd11",
@@ -75,8 +75,8 @@
       "version": "0.2.0-bb887713"
     },
     "js/auth-validation.js": {
-      "hash": "2c42c9c3",
-      "version": "0.2.0-2c42c9c3"
+      "hash": "67ec8402",
+      "version": "0.2.0-67ec8402"
     }
   }
 }

--- a/.version.json
+++ b/.version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.2.0",
-  "generatedAt": "2026-05-05T12:06:46.363Z",
+  "generatedAt": "2026-05-05T12:14:55.945Z",
   "resources": {
     "css/account-pages.css": {
       "hash": "643fdd11",
@@ -75,8 +75,8 @@
       "version": "0.2.0-bb887713"
     },
     "js/auth-validation.js": {
-      "hash": "741dd6b3",
-      "version": "0.2.0-741dd6b3"
+      "hash": "2c42c9c3",
+      "version": "0.2.0-2c42c9c3"
     }
   }
 }

--- a/public/js/auth-validation.js
+++ b/public/js/auth-validation.js
@@ -4,7 +4,25 @@
   var nextErrorId = 0;
 
   function getFieldLabel(field) {
-    return field.getAttribute('aria-label') || field.getAttribute('placeholder') || field.name || '该字段';
+    var label;
+    var labels;
+    var index;
+
+    if (field.id) {
+      labels = document.querySelectorAll('label');
+      for (index = 0; index < labels.length; index += 1) {
+        if (labels[index].htmlFor === field.id) {
+          label = labels[index];
+          break;
+        }
+      }
+    }
+
+    return field.getAttribute('aria-label') ||
+      (label ? label.textContent.trim() : '') ||
+      field.getAttribute('placeholder') ||
+      field.name ||
+      '该字段';
   }
 
   function ensureErrorElement(field) {

--- a/public/js/auth-validation.js
+++ b/public/js/auth-validation.js
@@ -5,17 +5,9 @@
 
   function getFieldLabel(field) {
     var label;
-    var labels;
-    var index;
 
-    if (field.id) {
-      labels = document.querySelectorAll('label');
-      for (index = 0; index < labels.length; index += 1) {
-        if (labels[index].htmlFor === field.id) {
-          label = labels[index];
-          break;
-        }
-      }
+    if (field.labels && field.labels.length > 0) {
+      label = field.labels[0];
     }
 
     return field.getAttribute('aria-label') ||

--- a/views/delete-account.ejs
+++ b/views/delete-account.ejs
@@ -3,7 +3,8 @@
 <head>
   <%- include('partials/document-head', {
     pageTitle: '注销账号',
-    accountPage: true
+    accountPage: true,
+    authValidationScript: true
   }) %>
 </head>
 <body>
@@ -25,15 +26,15 @@
         </div>
       <% } %>
 
-      <form action="/settings/delete" method="POST">
+      <form action="/settings/delete" method="POST" data-auth-validation>
         <div class="form-group form-group--compact">
-          <label>邮箱</label>
-          <input type="email" name="email" placeholder="请输入您的邮箱">
+          <label for="delete-account-email">邮箱</label>
+          <input id="delete-account-email" type="email" name="email" placeholder="请输入您的邮箱" autocomplete="username" autocapitalize="none" autocorrect="off" inputmode="email" data-auth-field="email" required>
         </div>
 
         <div class="form-group form-group--final">
-          <label>密码</label>
-          <input type="password" name="password" placeholder="请输入您的密码">
+          <label for="delete-account-password">密码</label>
+          <input id="delete-account-password" type="password" name="password" placeholder="请输入您的密码" autocomplete="current-password" data-auth-field="login-password" required>
         </div>
 
         <% if (typeof csrfToken !== 'undefined') { %>

--- a/views/password.ejs
+++ b/views/password.ejs
@@ -3,7 +3,8 @@
 <head>
   <%- include('partials/document-head', {
     pageTitle: '修改密码',
-    accountPage: true
+    accountPage: true,
+    authValidationScript: true
   }) %>
 </head>
 <body>
@@ -19,21 +20,21 @@
         </div>
       <% } %>
 
-      <form action="/settings/password" method="POST">
+      <form action="/settings/password" method="POST" data-auth-validation>
         <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <div class="form-group form-group--compact">
           <label for="settings-current-password">当前密码</label>
-          <input id="settings-current-password" type="password" name="currentPassword" placeholder="请输入当前密码">
+          <input id="settings-current-password" type="password" name="currentPassword" placeholder="请输入当前密码" autocomplete="current-password" data-auth-field="login-password" required>
         </div>
 
         <div class="form-group form-group--compact">
           <label for="settings-new-password">新密码</label>
-          <input id="settings-new-password" type="password" name="newPassword" placeholder="至少6位" minlength="6">
+          <input id="settings-new-password" type="password" name="newPassword" placeholder="至少6位" autocomplete="new-password" data-auth-field="password" required minlength="6">
         </div>
 
         <div class="form-group form-group--final">
           <label for="settings-confirm-password">确认新密码</label>
-          <input id="settings-confirm-password" type="password" name="confirmPassword" placeholder="再次输入新密码">
+          <input id="settings-confirm-password" type="password" name="confirmPassword" placeholder="再次输入新密码" autocomplete="new-password" data-auth-field="confirm-password" data-auth-match="newPassword" required>
         </div>
 
         <button type="submit" class="btn btn-secondary">修改密码</button>


### PR DESCRIPTION
﻿## 变更内容
- 修改密码和注销账号表单接入 `auth-validation.js`。
- 修改密码表单补充当前密码、新密码、确认新密码的即时校验。
- 注销账号表单补充邮箱格式和密码必填即时校验。
- 保留浏览器原生校验兜底；脚本绑定成功后才启用自定义校验。
- 不修改后端校验、CSRF 或账号注销业务规则。

## 验证
- `node --check public/js/auth-validation.js`
- 修改密码 / 注销账号 EJS render smoke test
- `npm test`
- `git diff --cached --check`

Refs #172
