### PR TITLE
增强：添加情侣匹配申请即时校验

### DIFF
--- a/.version.json
+++ b/.version.json
@@ -1,10 +1,10 @@
 {
   "version": "0.2.0",
-  "generatedAt": "2026-05-05T12:47:33.855Z",
+  "generatedAt": "2026-05-05T12:57:05.477Z",
   "resources": {
     "css/account-pages.css": {
-      "hash": "643fdd11",
-      "version": "0.2.0-643fdd11"
+      "hash": "0caa3282",
+      "version": "0.2.0-0caa3282"
     },
     "css/dev-tools.css": {
       "hash": "1fdea12d",
@@ -15,8 +15,8 @@
       "version": "0.2.0-cd7871cc"
     },
     "css/style.css": {
-      "hash": "eff67301",
-      "version": "0.2.0-eff67301"
+      "hash": "e76b10e5",
+      "version": "0.2.0-e76b10e5"
     },
     "favicon.ico": {
       "hash": "5ecd6c3b",

--- a/.version.json
+++ b/.version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.2.0",
-  "generatedAt": "2026-05-05T12:35:07.287Z",
+  "generatedAt": "2026-05-05T12:47:33.855Z",
   "resources": {
     "css/account-pages.css": {
       "hash": "643fdd11",
@@ -15,8 +15,8 @@
       "version": "0.2.0-cd7871cc"
     },
     "css/style.css": {
-      "hash": "e8c5ff05",
-      "version": "0.2.0-e8c5ff05"
+      "hash": "eff67301",
+      "version": "0.2.0-eff67301"
     },
     "favicon.ico": {
       "hash": "5ecd6c3b",

--- a/public/css/account-pages.css
+++ b/public/css/account-pages.css
@@ -109,19 +109,6 @@
   text-align: center;
 }
 
-.form-group--invalid input {
-  border-color: var(--error-border);
-  box-shadow: 0 0 0 3px rgba(232, 90, 90, 0.15);
-}
-
-.auth-field-error {
-  margin: 6px 0 0;
-  color: var(--error-foreground);
-  font-size: 0.78rem;
-  line-height: 1.4;
-  text-align: center;
-}
-
 .btn-full {
   width: 100%;
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -361,6 +361,30 @@ body {
   margin-top: 6px;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.form-group--invalid input {
+  border-color: var(--error-border);
+  box-shadow: 0 0 0 3px rgba(232, 90, 90, 0.15);
+}
+
+.auth-field-error {
+  margin: 6px 0 0;
+  color: var(--error-foreground);
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+
 /* 复选框组 */
 .checkbox-group {
   display: flex;
@@ -1106,8 +1130,15 @@ body {
 }
 
 .match-flow-row {
+  align-items: flex-start;
   display: flex;
   gap: 12px;
+}
+
+.match-flow-field {
+  flex: 1;
+  margin-bottom: 0;
+  width: 100%;
 }
 
 .match-flow-input {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -383,6 +383,7 @@ body {
   color: var(--error-foreground);
   font-size: 0.78rem;
   line-height: 1.4;
+  text-align: center;
 }
 
 /* 复选框组 */

--- a/views/couple-match.ejs
+++ b/views/couple-match.ejs
@@ -1,7 +1,11 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
-  <%- include('partials/document-head', { pageTitle: '情侣匹配', devToolsStyles: true }) %>
+  <%- include('partials/document-head', {
+    pageTitle: '情侣匹配',
+    devToolsStyles: true,
+    authValidationScript: true
+  }) %>
 </head>
 <body>
   <%- include('partials/navbar') %>
@@ -20,16 +24,25 @@
         输入对方邮箱，向TA发送情侣匹配申请。双方完成问卷后，在通知中心同意即可查看匹配结果。
       </p>
 
-      <form method="POST" action="/couple-match/request" class="match-flow-form">
+      <form method="POST" action="/couple-match/request" class="match-flow-form" data-auth-validation>
         <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <div class="match-flow-row">
-          <input
-            type="email"
-            name="email"
-            placeholder="对方邮箱（@shu.edu.cn）"
-            required
-            class="match-flow-input"
-          >
+          <div class="form-group match-flow-field">
+            <label class="sr-only" for="couple-match-email">对方学校邮箱</label>
+            <input
+              id="couple-match-email"
+              type="email"
+              name="email"
+              placeholder="对方邮箱（@shu.edu.cn）"
+              autocomplete="username"
+              autocapitalize="none"
+              autocorrect="off"
+              inputmode="email"
+              data-auth-field="shu-email"
+              required
+              class="match-flow-input"
+            >
+          </div>
           <button type="submit" class="btn btn-primary">发送申请</button>
         </div>
       </form>

--- a/views/couple-match.ejs
+++ b/views/couple-match.ejs
@@ -34,7 +34,7 @@
               type="email"
               name="email"
               placeholder="对方邮箱（@shu.edu.cn）"
-              autocomplete="username"
+              autocomplete="email"
               autocapitalize="none"
               autocorrect="off"
               inputmode="email"


### PR DESCRIPTION
﻿## 变更内容
- 情侣匹配申请表单接入 `auth-validation.js` 即时校验。
- 对方邮箱输入补充隐藏 label、自动填充属性、移动端邮箱键盘提示和 `shu-email` 校验规则。
- 将通用即时校验错误样式提升到全局样式，匹配页不再依赖账号页样式也能显示错误提示。
- 不修改后端校验、CSRF 或情侣匹配业务规则。

## 验证
- 情侣匹配页 EJS render smoke test
- 表单钩子 / 校验字段 / 错误样式静态断言
- `npm test`
- `git diff --cached --check`

Refs #172
