### PR TITLE
增强：让错误页复用公共壳层

### DIFF
--- a/app.js
+++ b/app.js
@@ -570,18 +570,31 @@ const requireValidNotificationsCsrf = createCsrfValidator('/notifications');
 const requireValidDevLoginCsrf = createCsrfValidator('/');
 
 function renderSafely(res, status, view, locals = {}, fallbackMessage = '页面暂时不可用') {
-  res.status(status).render(view, locals, (renderErr, html) => {
-    if (!renderErr) {
-      return res.send(html);
+  res.render(view, locals, (viewErr, body) => {
+    if (viewErr) {
+      console.error(`❌ 渲染 ${view} 内容失败:`, viewErr.message);
+      if (!res.headersSent) {
+        return res
+          .status(status)
+          .type('text/plain; charset=utf-8')
+          .send(locals.message || fallbackMessage);
+      }
+      return;
     }
 
-    console.error(`❌ 渲染 ${view} 失败:`, renderErr.message);
-    if (!res.headersSent) {
-      res
-        .status(status)
-        .type('text/plain; charset=utf-8')
-        .send(locals.message || fallbackMessage);
-    }
+    res.status(status).render('layout', { ...locals, body }, (layoutErr, html) => {
+      if (!layoutErr) {
+        return res.send(html);
+      }
+
+      console.error('❌ 渲染 layout 失败:', layoutErr.message);
+      if (!res.headersSent) {
+        res
+          .status(status)
+          .type('text/plain; charset=utf-8')
+          .send(locals.message || fallbackMessage);
+      }
+    });
   });
 }
 
@@ -2829,7 +2842,8 @@ app.use((err, req, res, next) => {
   renderSafely(res, 500, 'error', {
     title: '服务器异常',
     statusCode: 500,
-    message: isProduction ? '服务器开了点小差，请稍后再试。' : err.message
+    message: isProduction ? '服务器开了点小差，请稍后再试。' : err.message,
+    historyBackScript: true
   }, isProduction ? '服务器内部错误' : err.message);
 });
 

--- a/views/404.ejs
+++ b/views/404.ejs
@@ -1,27 +1,15 @@
-<!DOCTYPE html>
-<html lang="zh-CN">
-<head>
-  <%- include('partials/document-head', { pageTitle: typeof title !== 'undefined' ? title : '页面不存在' }) %>
-</head>
-<body>
-  <%- include('partials/navbar') %>
-
-  <div class="container message-page">
-    <div class="card message-card">
-      <div class="message-icon">🧭</div>
-      <p class="message-code">
-        <%= typeof statusCode !== 'undefined' ? statusCode : 404 %>
-      </p>
-      <h1 class="message-title">这个页面不在这里</h1>
-      <p class="message-text">
-        <%= typeof message !== 'undefined' && message ? message : '你访问的页面不存在，可能已被移动或删除。' %>
-      </p>
-      <div class="message-actions">
-        <a href="/" class="btn">回到首页</a>
-        <a href="/login" class="btn btn-secondary">去登录</a>
-      </div>
+<div class="container message-page">
+  <div class="card message-card">
+    <div class="message-icon">🧭</div>
+    <p class="message-code">
+      <%= typeof statusCode !== 'undefined' ? statusCode : 404 %>
+    </p>
+    <h1 class="message-title">这个页面不在这里</h1>
+    <p class="message-text">
+      <%= typeof message !== 'undefined' && message ? message : '你访问的页面不存在，可能已被移动或删除。' %>
+    </p>
+    <div class="message-actions">
+      <a href="/" class="btn">回到首页</a>
+      <a href="/login" class="btn btn-secondary">去登录</a>
     </div>
   </div>
-  <%- include('partials/site-footer') %>
-</body>
-</html>

--- a/views/error.ejs
+++ b/views/error.ejs
@@ -1,30 +1,17 @@
-<!DOCTYPE html>
-<html lang="zh-CN">
-<head>
-  <%- include('partials/document-head', { pageTitle: typeof title !== 'undefined' ? title : '服务器异常' }) %>
-  <script src="/js/history-back.js?v=0.2.0" defer></script>
-</head>
-<body>
-  <%- include('partials/navbar') %>
-
-  <div class="container message-page">
-    <div class="card message-card">
-      <div class="message-icon">⚠️</div>
-      <p class="message-code">
-        <%= typeof statusCode !== 'undefined' ? statusCode : 500 %>
-      </p>
-      <h1 class="message-title">服务器出了点问题</h1>
-      <p class="message-text">
-        <%= typeof message !== 'undefined' && message ? message : '服务器内部错误，请稍后再试。' %>
-      </p>
-      <div class="message-actions">
-        <a href="/" class="btn">返回首页</a>
-        <button type="button" class="btn btn-secondary" data-history-back>
-          返回上一页
-        </button>
-      </div>
+<div class="container message-page">
+  <div class="card message-card">
+    <div class="message-icon">⚠️</div>
+    <p class="message-code">
+      <%= typeof statusCode !== 'undefined' ? statusCode : 500 %>
+    </p>
+    <h1 class="message-title">服务器出了点问题</h1>
+    <p class="message-text">
+      <%= typeof message !== 'undefined' && message ? message : '服务器内部错误，请稍后再试。' %>
+    </p>
+    <div class="message-actions">
+      <a href="/" class="btn">返回首页</a>
+      <button type="button" class="btn btn-secondary" data-history-back>
+        返回上一页
+      </button>
     </div>
   </div>
-  <%- include('partials/site-footer') %>
-</body>
-</html>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -1,39 +1,20 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
-  <%- include('partials/document-head', { devToolsStyles: true }) %>
+  <%- include('partials/document-head', {
+    pageTitle: typeof pageTitle !== 'undefined' ? pageTitle : (typeof title !== 'undefined' ? title : ''),
+    fullTitle: typeof fullTitle !== 'undefined' ? fullTitle : '',
+    accountPage: typeof accountPage !== 'undefined' && accountPage,
+    loginTabsScript: typeof loginTabsScript !== 'undefined' && loginTabsScript,
+    authValidationScript: typeof authValidationScript !== 'undefined' && authValidationScript,
+    historyBackScript: typeof historyBackScript !== 'undefined' && historyBackScript,
+    devToolsStyles: typeof devToolsStyles !== 'undefined' ? devToolsStyles : true
+  }) %>
 </head>
-<body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="/" class="logo">心有所<span>SHU</span></a>
-      <div class="nav-links">
-        <% if (typeof user !== 'undefined' && user) { %>
-          <a href="/profile">我的资料</a>
-          <a href="/matches">匹配结果</a>
-          <% if (typeof isAdmin !== 'undefined' && isAdmin) { %>
-            <a href="/admin">管理</a>
-          <% } %>
-          <a href="/logout" class="btn">退出</a>
-        <% } else { %>
-          <a href="/login" class="btn">登录</a>
-        <% } %>
-      </div>
-    </div>
-  </nav>
-
-  <div class="container layout-main">
-    <% if (typeof message !== 'undefined' && message) { %>
-      <div class="alert alert-<%= messageType || 'info' %>"><%= message %></div>
-    <% } %>
-
-    <%- body %>
-  </div>
-
-  <footer class="footer">
-    <p>© 2026 心有所SHU - 上海大学校园交友匹配系统</p>
-  </footer>
-
+<body<% if (typeof bodyClass !== 'undefined' && bodyClass) { %> class="<%= bodyClass %>"<% } %>>
+  <%- include('partials/navbar') %>
+  <%- body %>
+  <%- include('partials/site-footer') %>
   <% if (typeof isDev !== 'undefined' && isDev) { %>
   <%- include('partials/dev-tools') %>
   <% } %>

--- a/views/partials/document-head.ejs
+++ b/views/partials/document-head.ejs
@@ -7,6 +7,7 @@
   const includeAccountStyles = typeof accountPage !== 'undefined' && accountPage;
   const includeLoginTabsScript = typeof loginTabsScript !== 'undefined' && loginTabsScript;
   const includeAuthValidationScript = typeof authValidationScript !== 'undefined' && authValidationScript;
+  const includeHistoryBackScript = typeof historyBackScript !== 'undefined' && historyBackScript;
   const includeDevToolsStyles = typeof devToolsStyles !== 'undefined' && devToolsStyles && typeof isDev !== 'undefined' && isDev;
 %>
 <meta charset="UTF-8">
@@ -25,4 +26,7 @@
 <% } %>
 <% if (includeAuthValidationScript) { %>
   <script src="/js/auth-validation.js?v=0.2.0" defer></script>
+<% } %>
+<% if (includeHistoryBackScript) { %>
+  <script src="/js/history-back.js?v=0.2.0" defer></script>
 <% } %>


### PR DESCRIPTION
﻿## 变更内容
- 将 `views/layout.ejs` 改成复用当前 `partials/document-head`、`partials/navbar`、`partials/site-footer` 和开发者工具的公共页面壳层。
- 让 404 / 500 错误页作为内容片段通过公共壳层渲染，作为 #171 的第一批低风险迁移页面。
- 在 `document-head` 中补充 `historyBackScript` 开关，保留 500 页“返回上一页”的现有脚本能力。
- 不迁移业务页面，不修改路由业务逻辑或页面视觉结构。

## 验证
- `node --check app.js`
- 404 / error layout render smoke test
- `npm test`
- `git diff --cached --check`

Refs #171
