### PR TITLE
增强：迁移简单页面到公共壳层

### DIFF
--- a/app.js
+++ b/app.js
@@ -543,6 +543,14 @@ function renderViewWithCsrf(req, res, view, model = {}) {
   return res.render(view, withCsrfToken(req, model));
 }
 
+function createTemplateRenderError(view, phase, cause) {
+  const error = new Error(`${phase} 模板 ${view} 渲染失败: ${cause.message}`);
+  error.cause = cause;
+  error.view = view;
+  error.phase = phase;
+  return error;
+}
+
 function renderTemplate(res, view, locals = {}) {
   return new Promise((resolve, reject) => {
     res.render(view, locals, (renderErr, html) => {
@@ -556,8 +564,21 @@ function renderTemplate(res, view, locals = {}) {
 }
 
 async function renderWithLayout(res, view, locals = {}, status = 200) {
-  const body = await renderTemplate(res, view, locals);
-  const html = await renderTemplate(res, 'layout', { ...locals, body });
+  let body;
+  let html;
+
+  try {
+    body = await renderTemplate(res, view, locals);
+  } catch (renderErr) {
+    throw createTemplateRenderError(view, '内容片段', renderErr);
+  }
+
+  try {
+    html = await renderTemplate(res, 'layout', { ...locals, body });
+  } catch (renderErr) {
+    throw createTemplateRenderError('layout', '页面壳层', renderErr);
+  }
+
   return res.status(status).send(html);
 }
 
@@ -593,7 +614,7 @@ const requireValidDevLoginCsrf = createCsrfValidator('/');
 
 function renderSafely(res, status, view, locals = {}, fallbackMessage = '页面暂时不可用') {
   renderWithLayout(res, view, locals, status).catch(renderErr => {
-    console.error(`❌ 渲染 ${view} 失败:`, renderErr.message);
+    console.error(`❌ ${renderErr.message}`);
     if (!res.headersSent) {
       res
         .status(status)
@@ -920,6 +941,7 @@ async function renderInfoPage(req, res, pageKey) {
     ...nav,
     title: page.title,
     pageTitle: page.pageTitle,
+    fullTitle: `${page.title} - 心有所SHU`,
     lead: page.lead,
     sections: page.sections,
     updatedAt: INFO_PAGE_UPDATED_AT

--- a/app.js
+++ b/app.js
@@ -543,6 +543,28 @@ function renderViewWithCsrf(req, res, view, model = {}) {
   return res.render(view, withCsrfToken(req, model));
 }
 
+function renderTemplate(res, view, locals = {}) {
+  return new Promise((resolve, reject) => {
+    res.render(view, locals, (renderErr, html) => {
+      if (renderErr) {
+        reject(renderErr);
+        return;
+      }
+      resolve(html);
+    });
+  });
+}
+
+async function renderWithLayout(res, view, locals = {}, status = 200) {
+  const body = await renderTemplate(res, view, locals);
+  const html = await renderTemplate(res, 'layout', { ...locals, body });
+  return res.status(status).send(html);
+}
+
+function renderViewWithCsrfInLayout(req, res, view, model = {}) {
+  return renderWithLayout(res, view, withCsrfToken(req, model));
+}
+
 function createCsrfValidator(redirectTo = '/admin') {
   return (req, res, next) => {
     // 兼容 _csrf（表单中常用） 和 csrfToken 两种字段名
@@ -570,31 +592,14 @@ const requireValidNotificationsCsrf = createCsrfValidator('/notifications');
 const requireValidDevLoginCsrf = createCsrfValidator('/');
 
 function renderSafely(res, status, view, locals = {}, fallbackMessage = '页面暂时不可用') {
-  res.render(view, locals, (viewErr, body) => {
-    if (viewErr) {
-      console.error(`❌ 渲染 ${view} 内容失败:`, viewErr.message);
-      if (!res.headersSent) {
-        return res
-          .status(status)
-          .type('text/plain; charset=utf-8')
-          .send(locals.message || fallbackMessage);
-      }
-      return;
+  renderWithLayout(res, view, locals, status).catch(renderErr => {
+    console.error(`❌ 渲染 ${view} 失败:`, renderErr.message);
+    if (!res.headersSent) {
+      res
+        .status(status)
+        .type('text/plain; charset=utf-8')
+        .send(locals.message || fallbackMessage);
     }
-
-    res.status(status).render('layout', { ...locals, body }, (layoutErr, html) => {
-      if (!layoutErr) {
-        return res.send(html);
-      }
-
-      console.error('❌ 渲染 layout 失败:', layoutErr.message);
-      if (!res.headersSent) {
-        res
-          .status(status)
-          .type('text/plain; charset=utf-8')
-          .send(locals.message || fallbackMessage);
-      }
-    });
   });
 }
 
@@ -911,7 +916,7 @@ async function renderInfoPage(req, res, pageKey) {
   const page = INFO_PAGES[pageKey];
   const nav = await buildPublicNavigationModel(req);
 
-  res.render('info-page', {
+  return renderWithLayout(res, 'info-page', {
     ...nav,
     title: page.title,
     pageTitle: page.pageTitle,
@@ -1491,10 +1496,12 @@ app.get('/profile', isLoggedIn, wrapAsync(async (req, res) => {
 // 账户设置
 app.get('/settings', isLoggedIn, wrapAsync(async (req, res) => {
   const profile = await db.queryOne('SELECT * FROM profiles WHERE user_id = $1', [req.user.id]);
-  res.render('settings', {
+  return renderWithLayout(res, 'settings', {
     user: req.user,
     nickname: req.session.nickname,
-    hasProfile: !!profile
+    hasProfile: !!profile,
+    pageTitle: '账户设置',
+    accountPage: true
   });
 }));
 
@@ -1515,13 +1522,15 @@ app.get('/notifications', isLoggedIn, wrapAsync(async (req, res) => {
     await db.execute('UPDATE notifications SET is_read = 1 WHERE user_id = $1 AND is_read = 0', [req.user.id]);
   }
 
-  renderViewWithCsrf(req, res, 'notifications', {
+  return renderViewWithCsrfInLayout(req, res, 'notifications', {
     user: req.user,
     nickname: req.session.nickname,
     hasProfile: req.user.hasProfile,
     notifications,
     message: req.query.msg,
-    messageType: req.query.type
+    messageType: req.query.type,
+    pageTitle: '通知中心',
+    devToolsStyles: true
   });
 }));
 

--- a/views/info-page.ejs
+++ b/views/info-page.ejs
@@ -1,39 +1,27 @@
-<!DOCTYPE html>
-<html lang="zh-CN">
-<head>
-  <%- include('partials/document-head', { fullTitle: title + ' - 心有所SHU' }) %>
-</head>
-<body>
-  <%- include('partials/navbar') %>
+<div class="container info-page">
+  <div class="card">
+    <p class="info-meta">最后更新：<%= updatedAt %></p>
+    <h1 class="info-title"><%= pageTitle %></h1>
+    <p class="info-lead"><%= lead %></p>
 
-  <div class="container info-page">
-    <div class="card">
-      <p class="info-meta">最后更新：<%= updatedAt %></p>
-      <h1 class="info-title"><%= pageTitle %></h1>
-      <p class="info-lead"><%= lead %></p>
+    <% sections.forEach(function(section) { %>
+      <section class="info-section">
+        <h2><%= section.title %></h2>
 
-      <% sections.forEach(function(section) { %>
-        <section class="info-section">
-          <h2><%= section.title %></h2>
+        <% if (section.paragraphs) { %>
+          <% section.paragraphs.forEach(function(paragraph) { %>
+            <p><%= paragraph %></p>
+          <% }); %>
+        <% } %>
 
-          <% if (section.paragraphs) { %>
-            <% section.paragraphs.forEach(function(paragraph) { %>
-              <p><%= paragraph %></p>
+        <% if (section.bullets) { %>
+          <ul>
+            <% section.bullets.forEach(function(item) { %>
+              <li><%= item %></li>
             <% }); %>
-          <% } %>
-
-          <% if (section.bullets) { %>
-            <ul>
-              <% section.bullets.forEach(function(item) { %>
-                <li><%= item %></li>
-              <% }); %>
-            </ul>
-          <% } %>
-        </section>
-      <% }); %>
-    </div>
+          </ul>
+        <% } %>
+      </section>
+    <% }); %>
   </div>
-
-  <%- include('partials/site-footer') %>
-</body>
-</html>
+</div>

--- a/views/notifications.ejs
+++ b/views/notifications.ejs
@@ -1,59 +1,48 @@
-<!DOCTYPE html>
-<html lang="zh-CN">
-<head>
-  <%- include('partials/document-head', { pageTitle: '通知中心', devToolsStyles: true }) %>
-</head>
-<body>
-  <%- include('partials/navbar') %>
+<div class="container notification-page">
+  <div class="card">
+    <h2 class="notification-title">通知中心</h2>
 
-  <div class="container notification-page">
-    <div class="card">
-      <h2 class="notification-title">通知中心</h2>
+    <% if (typeof message !== 'undefined' && message) { %>
+      <div class="alert alert-<%= messageType || 'info' %>">
+        <%= message %>
+      </div>
+    <% } %>
 
-      <% if (typeof message !== 'undefined' && message) { %>
-        <div class="alert alert-<%= messageType || 'info' %>">
-          <%= message %>
-        </div>
-      <% } %>
-
-      <% if (notifications && notifications.length > 0) { %>
-        <div class="notification-list">
-          <% notifications.forEach(function(notification) { %>
-            <div class="notification-item<%= !notification.is_read ? ' notification-item--unread' : '' %>">
-              <div class="notification-row">
-                <div class="notification-body">
-                  <p class="notification-content"><%= notification.content %></p>
-                  <p class="notification-time">
-                    <%= new Date(notification.created_at).toLocaleString('zh-CN') %>
-                  </p>
-                </div>
-                <% if (notification.type === 'match_request' && notification.status === 'pending') { %>
-                  <div class="notification-actions">
-                    <form method="POST" action="/couple-match/accept/<%= notification.related_request_id %>" class="inline-form">
-                      <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-                      <button type="submit" class="btn btn-primary btn-small">同意</button>
-                    </form>
-                    <form method="POST" action="/couple-match/reject/<%= notification.related_request_id %>" class="inline-form">
-                      <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-                      <button type="submit" class="btn btn-secondary btn-small">拒绝</button>
-                    </form>
-                  </div>
-                <% } else if (notification.type === 'match_accepted' && notification.related_request_id) { %>
-                  <div class="notification-action">
-                    <a href="/couple-match/result/<%= notification.related_request_id %>" class="btn btn-secondary btn-small">查看结果</a>
-                  </div>
-                <% } %>
+    <% if (notifications && notifications.length > 0) { %>
+      <div class="notification-list">
+        <% notifications.forEach(function(notification) { %>
+          <div class="notification-item<%= !notification.is_read ? ' notification-item--unread' : '' %>">
+            <div class="notification-row">
+              <div class="notification-body">
+                <p class="notification-content"><%= notification.content %></p>
+                <p class="notification-time">
+                  <%= new Date(notification.created_at).toLocaleString('zh-CN') %>
+                </p>
               </div>
+              <% if (notification.type === 'match_request' && notification.status === 'pending') { %>
+                <div class="notification-actions">
+                  <form method="POST" action="/couple-match/accept/<%= notification.related_request_id %>" class="inline-form">
+                    <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                    <button type="submit" class="btn btn-primary btn-small">同意</button>
+                  </form>
+                  <form method="POST" action="/couple-match/reject/<%= notification.related_request_id %>" class="inline-form">
+                    <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                    <button type="submit" class="btn btn-secondary btn-small">拒绝</button>
+                  </form>
+                </div>
+              <% } else if (notification.type === 'match_accepted' && notification.related_request_id) { %>
+                <div class="notification-action">
+                  <a href="/couple-match/result/<%= notification.related_request_id %>" class="btn btn-secondary btn-small">查看结果</a>
+                </div>
+              <% } %>
             </div>
-          <% }); %>
-        </div>
-      <% } else { %>
-        <div class="notification-empty">
-          <p>暂无通知</p>
-        </div>
-      <% } %>
-    </div>
+          </div>
+        <% }); %>
+      </div>
+    <% } else { %>
+      <div class="notification-empty">
+        <p>暂无通知</p>
+      </div>
+    <% } %>
   </div>
-  <%- include('partials/site-footer') %>
-</body>
-</html>
+</div>

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -1,31 +1,17 @@
-<!DOCTYPE html>
-<html lang="zh-CN">
-<head>
-  <%- include('partials/document-head', {
-    pageTitle: '账户设置',
-    accountPage: true
-  }) %>
-</head>
-<body>
-  <%- include('partials/navbar') %>
+<div class="container account-container">
+  <div class="card">
+    <h2 class="account-title account-title--settings">⚙️ 账户设置</h2>
 
-  <div class="container account-container">
-    <div class="card">
-      <h2 class="account-title account-title--settings">⚙️ 账户设置</h2>
+    <div class="settings-actions">
+      <a href="/settings/password" class="btn settings-action">
+        <span>🔐</span>
+        <span>修改密码</span>
+      </a>
 
-      <div class="settings-actions">
-        <a href="/settings/password" class="btn settings-action">
-          <span>🔐</span>
-          <span>修改密码</span>
-        </a>
-
-        <a href="/settings/delete" class="btn btn-danger settings-action">
-          <span>🗑️</span>
-          <span>注销账号</span>
-        </a>
-      </div>
+      <a href="/settings/delete" class="btn btn-danger settings-action">
+        <span>🗑️</span>
+        <span>注销账号</span>
+      </a>
     </div>
   </div>
-  <%- include('partials/site-footer') %>
-</body>
-</html>
+</div>


### PR DESCRIPTION
﻿## 变更内容
- 新增通用 `renderWithLayout()` / `renderViewWithCsrfInLayout()`，用于先渲染页面内容片段、再套用公共 `layout.ejs`。
- 将 `info-page.ejs`、`settings.ejs`、`notifications.ejs` 改成内容片段，统一通过公共壳层接入 head / navbar / footer / dev-tools。
- 保留说明页、设置页、通知页现有 locals、CSRF token、通知操作表单和页面样式开关。
- 不迁移认证页、匹配页、首页、profile 或 admin，避免扩大本批范围。

## 验证
- `node --check app.js`
- info-page / settings / notifications layout render smoke test
- `npm test`
- `git diff --cached --check`

Refs #171
