### PR TITLE
feat: 新增已确认但未匹配到同学的提示

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ const {
   getCurrentConfirmationWindowByTuesday19,
   getLastClosedConfirmationWindowByTuesday19,
   getConfirmationWindowForWeek,
+  getLastClosedWeekByTuesday19,
   isConfirmationIncludedInWindow
 } = require('./weekNumber');
 require('dotenv').config();
@@ -1787,6 +1788,13 @@ app.post('/confirm-match', isLoggedIn, requireValidCsrf, wrapAsync(async (req, r
     [currentWeekInfo.year, currentWeekInfo.week, req.user.id]
   );
 
+  // 记录到 weekly_confirmations 表（用于追踪历史确认状态）
+  await db.execute(`
+    INSERT INTO weekly_confirmations (user_id, confirm_year, confirm_week)
+    VALUES ($1, $2, $3)
+    ON CONFLICT (user_id, confirm_year, confirm_week) DO NOTHING
+  `, [req.user.id, currentWeekInfo.year, currentWeekInfo.week]);
+
   res.redirect('/?msg=已确认参与本周匹配&type=success');
 }));
 
@@ -1936,8 +1944,61 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
     }
   }
 
-  // 历史匹配（排除本周）
-  const historyList = matchList.filter(m => !(m.year === weekInfo.year && m.weekNumber === weekInfo.week));
+  // 计算上周信息（用于单独显示"上周"区域）
+  let lastWeekEntry = null;
+  const lastWeekInfo = getLastClosedWeekByTuesday19();
+  const lastWeekYear = lastWeekInfo.year;
+  const lastWeekNumber = lastWeekInfo.week;
+  // 如果上周有匹配记录，则为 matched 状态
+  const lastWeekMatch = matchList.find(m => m.year === lastWeekYear && m.weekNumber === lastWeekNumber);
+  if (lastWeekMatch) {
+    lastWeekEntry = { ...lastWeekMatch, status: 'matched' };
+  } else {
+    // 查询用户上周是否确认了匹配
+    const lastWeekConfirmed = await db.queryOne(
+      `SELECT 1 FROM weekly_confirmations WHERE user_id = $1 AND confirm_year = $2 AND confirm_week = $3`,
+      [req.user.id, lastWeekYear, lastWeekNumber]
+    );
+    if (lastWeekConfirmed) {
+      lastWeekEntry = { year: lastWeekYear, weekNumber: lastWeekNumber, status: 'no_match', matchId: null, partner: null, score: null };
+    }
+  }
+
+  // 历史匹配（排除本周和上周）
+  const historyList = matchList.filter(m => !(m.year === weekInfo.year && m.weekNumber === weekInfo.week) && !(m.year === lastWeekYear && m.weekNumber === lastWeekNumber));
+
+  // 查询用户所有确认但无匹配的周（用于补入历史记录）
+  const confirmedWeeks = await db.query(`
+    SELECT confirm_year, confirm_week
+    FROM weekly_confirmations
+    WHERE user_id = $1
+    ORDER BY confirm_year DESC, confirm_week DESC
+  `, [req.user.id]);
+
+  // 补入已确认但无匹配的周（排除本周和上周）
+  const matchedYearsWeeks = new Set(matchList.map(m => `${m.year}-${m.weekNumber}`));
+  const confirmedNoMatchEntries = [];
+  for (const row of confirmedWeeks) {
+    const key = `${row.confirm_year}-${row.confirm_week}`;
+    const isNotCurrentOrLastWeek = !(row.confirm_year === weekInfo.year && row.confirm_week === weekInfo.week) &&
+                                    !(row.confirm_year === lastWeekYear && row.confirm_week === lastWeekNumber);
+    if (isNotCurrentOrLastWeek && !matchedYearsWeeks.has(key)) {
+      confirmedNoMatchEntries.push({
+        matchId: null,
+        year: row.confirm_year,
+        weekNumber: row.confirm_week,
+        status: 'no_match',
+        partner: null,
+        score: null
+      });
+    }
+  }
+
+  // 合并历史匹配和未匹配记录
+  const fullHistoryList = [...historyList, ...confirmedNoMatchEntries].sort((a, b) => {
+    if (a.year !== b.year) return b.year - a.year;
+    return b.weekNumber - a.weekNumber;
+  });
 
   res.render('matches', {
     title: '匹配结果',
@@ -1945,8 +2006,9 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
     nickname: req.session.nickname,
     hasProfile: true,
     showPassword: true,
-    historyList,
+    historyList: fullHistoryList,
     currentWeekEntry,
+    lastWeekEntry,
     isAdmin: req.isAdmin,
     weeklyMatchEnabled,
     hasWeeklyRelease,

--- a/app.js
+++ b/app.js
@@ -1954,11 +1954,14 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
   if (lastWeekMatch) {
     lastWeekEntry = { ...lastWeekMatch, status: 'matched' };
   } else {
-    // 查询用户上周是否确认了匹配
+    // 查询用户上周是否确认了匹配（优先查 weekly_confirmations，回退查 users 表历史字段）
     const lastWeekConfirmed = await db.queryOne(
       `SELECT 1 FROM weekly_confirmations WHERE user_id = $1 AND confirm_year = $2 AND confirm_week = $3`,
       [req.user.id, lastWeekYear, lastWeekNumber]
     );
+    if (!lastWeekConfirmed && req.user.weekly_match_year === lastWeekYear && req.user.weekly_match_week === lastWeekNumber) {
+      lastWeekConfirmed = { dummy: 1 };
+    }
     if (lastWeekConfirmed) {
       lastWeekEntry = { year: lastWeekYear, weekNumber: lastWeekNumber, status: 'no_match', matchId: null, partner: null, score: null };
     }
@@ -1968,10 +1971,15 @@ app.get('/matches', isLoggedIn, wrapAsync(async (req, res) => {
   const historyList = matchList.filter(m => !(m.year === weekInfo.year && m.weekNumber === weekInfo.week) && !(m.year === lastWeekYear && m.weekNumber === lastWeekNumber));
 
   // 查询用户所有确认但无匹配的周（用于补入历史记录）
+  // 优先从 weekly_confirmations 读取；回退取 users 表的历史确认字段
   const confirmedWeeks = await db.query(`
     SELECT confirm_year, confirm_week
     FROM weekly_confirmations
     WHERE user_id = $1
+    UNION
+    SELECT weekly_match_year AS confirm_year, weekly_match_week AS confirm_week
+    FROM users
+    WHERE id = $1 AND weekly_match_year > 0 AND weekly_match_week > 0
     ORDER BY confirm_year DESC, confirm_week DESC
   `, [req.user.id]);
 

--- a/database.js
+++ b/database.js
@@ -184,6 +184,21 @@ await pool.query(`
   )
 `);
 
+// 每周匹配确认记录表（用于追踪历史确认状态）
+await pool.query(`
+  CREATE TABLE IF NOT EXISTS weekly_confirmations (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL,
+    confirm_year INTEGER NOT NULL,
+    confirm_week INTEGER NOT NULL,
+    confirmed_at TIMESTAMP DEFAULT NOW(),
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    UNIQUE(user_id, confirm_year, confirm_week)
+  )
+`);
+await pool.query(`CREATE INDEX IF NOT EXISTS idx_weekly_confirmations_user ON weekly_confirmations (user_id)`);
+await pool.query(`CREATE INDEX IF NOT EXISTS idx_weekly_confirmations_year_week ON weekly_confirmations (confirm_year, confirm_week)`);
+
 // 为现有数据添加 match_year 列（迁移）
 await pool.query(`ALTER TABLE matches ADD COLUMN IF NOT EXISTS match_year INTEGER`);
 await pool.query(`ALTER TABLE matches ADD COLUMN IF NOT EXISTS match_comment TEXT`);

--- a/views/matches.ejs
+++ b/views/matches.ejs
@@ -85,11 +85,47 @@
     </div>
     <% } %>
 
+    <% if (lastWeekEntry) { %>
+    <div class="card">
+      <h3 class="match-section-title match-section-title--simple">上周</h3>
+      <% if (lastWeekEntry.status === 'matched') { %>
+      <a href="/matches/detail/<%= lastWeekEntry.matchId %>" class="match-card match-card--link">
+        <div class="match-week">第<%= lastWeekEntry.weekNumber %>周</div>
+        <div class="match-info">
+          <div class="match-partner"><%= lastWeekEntry.partner.nickname || lastWeekEntry.partner.email %></div>
+          <% if (lastWeekEntry.score !== null && lastWeekEntry.score !== undefined) { %>
+          <% const scoreTone = lastWeekEntry.score >= 70 ? 'high' : (lastWeekEntry.score >= 50 ? 'medium' : 'low'); %>
+          <div class="match-score match-score--compact match-score--<%= scoreTone %>">
+            <%= Math.round(lastWeekEntry.score) %>分
+          </div>
+          <% } %>
+        </div>
+        <div class="match-card__action">查看详情 →</div>
+      </a>
+      <% } else if (lastWeekEntry.status === 'no_match') { %>
+      <div class="match-card match-card--no-match">
+        <div class="match-week">第<%= lastWeekEntry.weekNumber %>周</div>
+        <div class="match-info">
+          <div class="match-status match-status--warn">上周没匹配到合适的同学，下周再来吧～</div>
+        </div>
+      </div>
+      <% } %>
+    </div>
+    <% } %>
+
     <% if (historyList && historyList.length > 0) { %>
     <div class="card match-history-section">
       <h3 class="match-section-title match-section-title--simple match-section-title--muted">历史匹配</h3>
       <div class="match-list">
         <% historyList.forEach(function(m) { %>
+        <% if (m.status === 'no_match') { %>
+        <div class="match-card match-card--no-match">
+          <div class="match-week">第<%= m.weekNumber %>周</div>
+          <div class="match-info">
+            <div class="match-status match-status--warn">第<%= m.weekNumber %>周没匹配到合适的同学，下周再来吧～</div>
+          </div>
+        </div>
+        <% } else { %>
         <a href="/matches/detail/<%= m.matchId %>" class="match-card match-card--link">
           <div class="match-week">第<%= m.weekNumber %>周</div>
           <div class="match-info">
@@ -103,6 +139,7 @@
           </div>
           <div class="match-card__action">查看详情 →</div>
         </a>
+        <% } %>
         <% }); %>
       </div>
     </div>


### PR DESCRIPTION
- 新增 weekly_confirmations 表记录用户历史确认状态
- matches 页面新增"上周"区域，有匹配显示结果，无匹配但已确认显示"上周没匹配到合适的同学"
- 历史匹配中补入已确认但无匹配的周记录，显示"第xx周没匹配到合适的同学"

## Summary
- `app.js`: 查询用户已确认但无匹配的周，补全历史记录展示
- `database.js`: 新增 `weekly_confirmations` 表结构
- `matches.ejs`: 展示未匹配到同学的提示信息
