### PR TITLE
fix: 当上周有确认记录时，隐藏“无匹配记录”

### DIFF
--- a/views/matches.ejs
+++ b/views/matches.ejs
@@ -145,7 +145,7 @@
     </div>
     <% } %>
 
-    <% if ((!historyList || historyList.length === 0) && !currentWeekEntry) { %>
+    <% if ((!historyList || historyList.length === 0) && !currentWeekEntry && !lastWeekEntry) { %>
     <div class="card match-empty-card">
       <div class="match-empty-icon">🔍</div>
       <h2>暂无匹配记录</h2>


### PR DESCRIPTION
仅在用户既无本周记录也无上周记录时显示“暂无匹配记录”的空状态。如果只有上周的记录存在（例如已确认但无匹配），则显示上周的部分。