### PR TITLE
feat: 首页未确认匹配时也显示"看看匹配"按钮

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -74,6 +74,7 @@
               <a href="/matches" class="btn">看看匹配</a>
               <a href="/confirm-match" class="btn btn-secondary">取消确认</a>
               <% } else { %>
+              <a href="/matches" class="btn">看看匹配</a>
               <a href="/confirm-match" class="btn">确认匹配</a>
               <% } %>
             <% } else { %>


### PR DESCRIPTION
当用户已完成资料填写但未确认本周匹配时，在首页同时显示"看看匹配"和"确认匹配"按钮，顺序为：看看匹配、确认匹配、查看资料。